### PR TITLE
Fix network watchdog fallback and disable reboot by default

### DIFF
--- a/scripts/network_watchdog.py
+++ b/scripts/network_watchdog.py
@@ -4,10 +4,11 @@ WiFi network watchdog for Mesh Point.
 
 Standalone service (no meshpoint imports, stdlib only) that:
   1. Disables WiFi power save on startup
-  2. Pings the default gateway every CHECK_INTERVAL seconds
+  2. Pings the default gateway every CHECK_INTERVAL seconds,
+     falling back to FALLBACK_PING_TARGET if the gateway does not reply
   3. Escalates recovery on consecutive failures:
      - Stage 1: restart the wlan interface
-     - Stage 2: full system reboot
+     - Stage 2: full system reboot (disabled by default)
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ import time
 WIFI_INTERFACE = "wlan0"
 CHECK_INTERVAL_SECONDS = 120
 RESTART_THRESHOLD = 3
-REBOOT_THRESHOLD = 6
+REBOOT_THRESHOLD = 0
 PING_TIMEOUT_SECONDS = 5
 FALLBACK_PING_TARGET = "8.8.8.8"
 
@@ -32,16 +33,21 @@ logger = logging.getLogger("network-watchdog")
 
 
 class ConnectivityProbe:
-    """Checks reachability of the default gateway via ICMP ping."""
+    """Checks network reachability via ICMP ping."""
 
     def __init__(self, timeout_seconds: int = PING_TIMEOUT_SECONDS) -> None:
         self._timeout = timeout_seconds
 
     def check(self) -> bool:
-        target = self._detect_gateway() or FALLBACK_PING_TARGET
-        return self._ping(target)
+        gateway = self._detect_gateway()
+        if gateway:
+            if self._ping(gateway):
+                return True
+            logger.debug("Gateway %s did not respond, trying fallback", gateway)
+        return self._ping(FALLBACK_PING_TARGET)
 
     def _ping(self, target: str) -> bool:
+        logger.debug("Pinging %s", target)
         try:
             result = subprocess.run(
                 ["ping", "-c", "1", "-W", str(self._timeout), target],
@@ -77,7 +83,12 @@ class NetworkWatchdog:
         self._consecutive_failures = 0
 
     def run(self) -> None:
-        logger.info("Starting network watchdog (interface=%s)", WIFI_INTERFACE)
+        logger.info(
+            "Starting network watchdog (interface=%s, restart=%d, reboot=%s)",
+            WIFI_INTERFACE,
+            RESTART_THRESHOLD,
+            REBOOT_THRESHOLD if REBOOT_THRESHOLD > 0 else "disabled",
+        )
         self._disable_power_save()
 
         while True:
@@ -99,7 +110,7 @@ class NetworkWatchdog:
             "Connectivity check failed (%d consecutive)", self._consecutive_failures
         )
 
-        if self._consecutive_failures >= REBOOT_THRESHOLD:
+        if REBOOT_THRESHOLD > 0 and self._consecutive_failures >= REBOOT_THRESHOLD:
             self._reboot()
         elif self._consecutive_failures >= RESTART_THRESHOLD:
             self._restart_interface()


### PR DESCRIPTION
## Summary

- **Fix fallback probe logic**: the connectivity check only used the fallback target (`8.8.8.8`) when gateway *detection* failed (no route entry), not when the gateway didn't *respond* to ICMP. Now tries the gateway first, then falls back to `8.8.8.8` on ping failure. Many common routers (e.g. Ubiquiti) silently drop ICMP echo, so a working internet connection was treated as a total connectivity failure.
- **Disable reboot by default**: `REBOOT_THRESHOLD` set to `0` (disabled). The previous default of `6` caused the device to reboot every ~12 minutes on networks where the gateway doesn't respond to ping — even though WiFi and internet were fully functional. Set to a positive integer to re-enable.
- **Improved startup logging**: log the active thresholds and whether reboot is enabled so operators can verify configuration from the journal.

## Context

On a Mesh Point deployed behind a Ubiquiti router, the gateway (`172.16.0.1`) responds to DNS and forwards traffic normally but drops ICMP echo requests. The watchdog detected the gateway IP correctly from `/proc/net/route`, but the `or`-based fallback never fired because detection succeeded — only the ping failed. After 6 consecutive failures (~12 min), the watchdog rebooted the Pi, which then repeated the cycle indefinitely.

## Test plan

- [ ] Deploy on a network where the gateway responds to ping — verify watchdog reports success on the gateway ping (fallback not needed)
- [ ] Deploy on a network where the gateway drops ICMP — verify watchdog falls back to `8.8.8.8` and reports success, no interface restart or reboot
- [ ] Disconnect WiFi entirely — verify stage 1 recovery (interface restart) still triggers at `RESTART_THRESHOLD`
- [ ] Set `REBOOT_THRESHOLD = 6` — verify stage 2 reboot triggers after sustained failure
- [ ] Verify `REBOOT_THRESHOLD = 0` never triggers a reboot regardless of failure count