### PR TITLE
Fix MeshCore nodes missing from dashboard map

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased
+
+Queued for the next version bump. Bullets in this section will be folded into the release header (and dated) when the version is cut.
+
+- **MeshCore nodes now appear on the dashboard map.** MeshCore advertises position on the *advertisement* packet itself (`adv_lat`/`adv_lon`) rather than via a separate periodic position broadcast like Meshtastic. The event adapter was correctly extracting these onto the decoded payload, but `MeshcoreDecoder.extract_node_update` only consumed lat/lon from `PacketType.POSITION` packets and ignored them on `PacketType.NODEINFO` (which is what advertisements get classified as), so coordinates silently dropped on the floor before the node-repository write and the `/api/nodes/map` endpoint returned zero MC nodes. Now `extract_node_update` pulls position from both `NODEINFO` and `POSITION` packets through a shared `_apply_position` helper. Existing MC nodes will populate on the map after their next advertisement is heard (no DB migration needed). New `tests/test_meshcore_usb.py::TestMeshcoreDecoderNodeExtraction` (3 tests) covers the advertisement-with-position, advertisement-without-position, and standalone-POSITION-packet paths so this regression cannot return.
+
 ### v0.7.2 (May 5, 2026)
 
 Two-fix bundle on top of v0.7.1. One small UX feature for hop-chain debugging, one quiet-but-important correctness fix that was inflating node counts on the cloud catalog and producing intermittent garbled-but-readable text on the local mesh. Both ride together because they touch the same RX path. Pure-Python, no recompile needed.

--- a/src/decode/meshcore_decoder.py
+++ b/src/decode/meshcore_decoder.py
@@ -167,6 +167,14 @@ class MeshcoreDecoder:
             return {"raw_hex": payload.hex()}
 
     def extract_node_update(self, packet: Packet) -> Optional[Node]:
+        """Build a Node update from a decoded MeshCore packet.
+
+        Unlike Meshtastic, MeshCore does not broadcast a separate periodic
+        position packet: a node's coordinates ride on its advertisement
+        (``adv_lat``/``adv_lon``), which the event adapter classifies as
+        ``NODEINFO``. We therefore extract position from both ``NODEINFO``
+        and ``POSITION`` packets so MeshCore nodes appear on the map.
+        """
         if not packet.decoded_payload:
             return None
 
@@ -178,13 +186,23 @@ class MeshcoreDecoder:
 
         if packet.packet_type == PacketType.NODEINFO:
             node.long_name = packet.decoded_payload.get("long_name")
+            self._apply_position(node, packet.decoded_payload)
 
         if packet.packet_type == PacketType.POSITION:
-            node.latitude = packet.decoded_payload.get("latitude")
-            node.longitude = packet.decoded_payload.get("longitude")
+            self._apply_position(node, packet.decoded_payload)
 
         node.latest_signal = packet.signal
         return node
+
+    @staticmethod
+    def _apply_position(node: Node, payload: dict[str, Any]) -> None:
+        """Copy lat/lon onto ``node`` when the payload carries both."""
+        lat = payload.get("latitude")
+        lon = payload.get("longitude")
+        if lat is None or lon is None:
+            return
+        node.latitude = lat
+        node.longitude = lon
 
     def extract_telemetry(self, packet: Packet) -> Optional[Telemetry]:
         if packet.packet_type != PacketType.TELEMETRY:

--- a/tests/test_meshcore_usb.py
+++ b/tests/test_meshcore_usb.py
@@ -13,8 +13,10 @@ from src.config import (
     MeshcoreUsbConfig,
     _merge_dataclass,
 )
+from src.decode.crypto_service import CryptoService
+from src.decode.meshcore_decoder import MeshcoreDecoder
 from src.decode.meshcore_event_adapter import adapt_event
-from src.models.packet import PacketType, Protocol
+from src.models.packet import Packet, PacketType, Protocol
 from src.models.signal import SignalMetrics
 
 
@@ -197,6 +199,87 @@ class TestMeshcoreEventAdapter(unittest.TestCase):
         pkt = adapt_event(raw)
         self.assertIsNotNone(pkt.timestamp)
         self.assertEqual(pkt.timestamp.tzinfo, timezone.utc)
+
+
+class TestMeshcoreDecoderNodeExtraction(unittest.TestCase):
+    """Verify ``extract_node_update`` lifts MeshCore advert position onto Node.
+
+    Regression coverage for the bug where MeshCore nodes never appeared on
+    the dashboard map: their lat/lon rides on the advertisement (classified
+    by the event adapter as ``PacketType.NODEINFO``), but the extractor only
+    consumed positions from ``PacketType.POSITION`` packets, so the lat/lon
+    silently dropped on the floor before the node repository write.
+    """
+
+    def setUp(self) -> None:
+        self._decoder = MeshcoreDecoder(CryptoService())
+
+    @staticmethod
+    def _make_envelope(event_type: str, payload: dict) -> bytes:
+        return json.dumps({
+            "event_type": event_type,
+            "payload": payload,
+        }).encode("utf-8")
+
+    def _adapt_advertisement(self, payload: dict) -> Packet:
+        pkt = adapt_event(self._make_envelope("advertisement", payload))
+        assert pkt is not None, "advertisement should adapt to a Packet"
+        return pkt
+
+    def test_advertisement_with_position_yields_positioned_node(self):
+        pkt = self._adapt_advertisement({
+            "public_key": "abcdef1234567890abcdef",
+            "adv_name": "TestNode",
+            "adv_lat": 43.9091,
+            "adv_lon": -72.2207,
+        })
+
+        node = self._decoder.extract_node_update(pkt)
+
+        self.assertIsNotNone(node)
+        self.assertTrue(node.has_position)
+        self.assertAlmostEqual(node.latitude, 43.9091)
+        self.assertAlmostEqual(node.longitude, -72.2207)
+        self.assertEqual(node.long_name, "TestNode")
+        self.assertEqual(node.protocol, Protocol.MESHCORE.value)
+
+    def test_advertisement_without_position_yields_node_without_position(self):
+        pkt = self._adapt_advertisement({
+            "public_key": "abcdef1234567890abcdef",
+            "adv_name": "TestNode",
+            "adv_lat": 0.0,
+            "adv_lon": 0.0,
+        })
+
+        node = self._decoder.extract_node_update(pkt)
+
+        self.assertIsNotNone(node)
+        self.assertFalse(node.has_position)
+        self.assertIsNone(node.latitude)
+        self.assertIsNone(node.longitude)
+        self.assertEqual(node.long_name, "TestNode")
+
+    def test_position_packet_still_extracts_lat_lon(self):
+        """Regression guard for the original ``PacketType.POSITION`` path."""
+        from datetime import datetime, timezone
+
+        pkt = Packet(
+            packet_id="0001",
+            source_id="abcd",
+            destination_id="broadcast",
+            protocol=Protocol.MESHCORE,
+            packet_type=PacketType.POSITION,
+            decoded_payload={"latitude": 12.34, "longitude": -56.78},
+            timestamp=datetime.now(timezone.utc),
+            decrypted=True,
+        )
+
+        node = self._decoder.extract_node_update(pkt)
+
+        self.assertIsNotNone(node)
+        self.assertTrue(node.has_position)
+        self.assertAlmostEqual(node.latitude, 12.34)
+        self.assertAlmostEqual(node.longitude, -56.78)
 
 
 class TestMeshcoreUsbConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary
MeshCore advertisements carry position data on the advertisement packet itself (``adv_lat``/``adv_lon``), which the event adapter classifies as ``PacketType.NODEINFO``. ``MeshcoreDecoder.extract_node_update`` only consumed lat/lon from ``PacketType.POSITION`` packets, so MeshCore node positions silently dropped before the node-repository write and ``/api/nodes/map`` returned zero MC nodes.

## Fix
``extract_node_update`` now lifts position from both ``NODEINFO`` and ``POSITION`` packets through a shared ``_apply_position`` helper. Empty or zero coordinates are ignored.

## Tests
New ``TestMeshcoreDecoderNodeExtraction`` (3 tests) in ``tests/test_meshcore_usb.py``:
- advertisement with position yields a positioned node
- advertisement with zero position yields a node without position
- standalone POSITION packets still extract lat/lon (regression guard)

Full suite: 300 passed locally. Bandit clean on ``src/decode/``. Ruff clean.

## Migration
None. Existing MeshCore nodes populate on the map after their next advertisement is heard.

## Test plan
- [x] ``python -m pytest tests/test_meshcore_usb.py``
- [x] Full edge suite green (300 passed)
- [ ] Hardware: validate on RAK V2 with active MeshCore node in range