### PR TITLE
Fix meshcore node names

### DIFF
--- a/src/api/meshcore_contacts.py
+++ b/src/api/meshcore_contacts.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+
+from src.models.packet import Packet, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+def setup_meshcore_contact_enrichment(coord, meshcore_tx=None) -> None:
+    """Keep MeshCore node rows named from the companion contact list."""
+    if meshcore_tx is None:
+        return
+
+    def on_meshcore_packet(packet: Packet) -> None:
+        if packet.protocol != Protocol.MESHCORE or not packet.source_id:
+            return
+
+        import asyncio
+        try:
+            asyncio.get_running_loop().create_task(
+                sync_meshcore_contacts_to_nodes(
+                    coord, meshcore_tx, packet.source_id
+                )
+            )
+        except RuntimeError:
+            pass
+
+    coord.on_packet(on_meshcore_packet)
+
+
+async def sync_meshcore_contacts_to_nodes(
+    coord,
+    meshcore_tx,
+    source_id: str = "",
+) -> int:
+    if not meshcore_tx or not meshcore_tx.connected:
+        return 0
+
+    source = source_id.lower().lstrip("!")
+    updated = 0
+    try:
+        contacts = await meshcore_tx.get_contacts()
+    except Exception:
+        logger.debug("MeshCore contact node enrichment failed", exc_info=True)
+        return 0
+
+    for contact in contacts:
+        pk = str(contact.get("public_key", "")).lower().lstrip("!")
+        name = str(contact.get("name", "")).strip()
+        if not pk or not name or _is_hex_identifier(name):
+            continue
+        prefixes = _meshcore_pubkey_prefixes(pk)
+        if source and not any(source.startswith(p) or p.startswith(source) for p in prefixes):
+            continue
+        short_name = name[:4]
+        for prefix in prefixes:
+            cursor = await coord.node_repo._db.execute(
+                """
+                UPDATE nodes
+                SET long_name = ?,
+                    short_name = CASE
+                        WHEN short_name IS NULL
+                          OR short_name = ''
+                          OR LOWER(LTRIM(short_name, '!')) = LOWER(SUBSTR(LTRIM(node_id, '!'), 1, 4))
+                            THEN ?
+                        ELSE short_name
+                    END
+                WHERE protocol = 'meshcore'
+                  AND LOWER(LTRIM(node_id, '!')) LIKE ?
+                """,
+                (name, short_name, prefix + "%"),
+            )
+            if cursor.rowcount and cursor.rowcount > 0:
+                updated += cursor.rowcount
+                break
+
+    if updated:
+        await coord.node_repo._db.commit()
+        logger.info("MeshCore contact names applied to %d node row(s)", updated)
+    return updated
+
+
+def _meshcore_pubkey_prefixes(pubkey: str) -> tuple[str, ...]:
+    lengths = (16, 12, 10, 8, len(pubkey))
+    return tuple(dict.fromkeys(pubkey[:n] for n in lengths if len(pubkey) >= n))
+
+
+def _is_hex_identifier(value: str) -> bool:
+    candidate = value.lower().lstrip("!")
+    try:
+        int(candidate, 16)
+        return len(candidate) >= 6
+    except ValueError:
+        return False

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -17,6 +17,10 @@ from src.api.auth.auth_bootstrap import AuthSubsystem, build_auth_subsystem
 from src.api.auth.dependencies import SESSION_COOKIE_NAME, require_auth
 from src.api.auth.jwt_session import JwtSessionService
 from src.api.auth.ws_guard import WS_AUTH_CLOSE_CODE, authenticate_websocket
+from src.api.meshcore_contacts import (
+    setup_meshcore_contact_enrichment,
+    sync_meshcore_contacts_to_nodes,
+)
 from src.api.routes import analytics, auth_routes, config_routes, device, identity_routes, messages, nodeinfo_routes, nodes, packets, stats_routes, system_metrics, telemetry, update_check
 from src.api.upstream_client import UpstreamClient
 from src.api.websocket_manager import WebSocketManager
@@ -87,6 +91,12 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         _setup_message_interception(
             pipeline, message_repo, config, meshcore_tx_ref
         )
+        setup_meshcore_contact_enrichment(pipeline, meshcore_tx_ref)
+        if meshcore_tx_ref and meshcore_tx_ref.connected:
+            import asyncio
+            asyncio.get_running_loop().create_task(
+                sync_meshcore_contacts_to_nodes(pipeline, meshcore_tx_ref)
+            )
 
         upstream = UpstreamClient(
             config.upstream, identity,

--- a/src/decode/meshcore_event_adapter.py
+++ b/src/decode/meshcore_event_adapter.py
@@ -131,21 +131,27 @@ def _build_advertisement(
         default="unknown",
     )
     source_id = pubkey[:12] if len(pubkey) >= 12 else pubkey
-    name = _first_payload_value(
+    name = _find_payload_name(
         payload,
         "adv_name",
+        "advName",
         "name",
         "long_name",
+        "longName",
         "display_name",
-        default="",
+        "displayName",
+        "node_name",
+        "nodeName",
+        "repeater_name",
+        "repeaterName",
     )
-    display_name = name or source_id
     decoded = {
-        "long_name": display_name,
-        "short_name": display_name[:4],
         "public_key": pubkey,
         "advertisement": payload,
     }
+    if name and not _looks_like_identifier(name, source_id, pubkey):
+        decoded["long_name"] = name
+        decoded["short_name"] = name[:4]
     lat = payload.get("adv_lat")
     lon = payload.get("adv_lon")
     if lat and lon:
@@ -173,6 +179,45 @@ def _first_payload_value(payload: dict, *keys: str, default: str = "") -> str:
         if value:
             return value
     return default
+
+
+def _find_payload_name(payload: dict, *keys: str) -> str:
+    """Find a display name even when the meshcore library nests advert data."""
+    direct = _first_payload_value(payload, *keys, default="")
+    if direct:
+        return direct
+
+    wanted = {k.lower() for k in keys}
+    stack = list(payload.values())
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if k.lower() in wanted and v is not None:
+                    candidate = str(v).strip()
+                    if candidate:
+                        return candidate
+                elif isinstance(v, (dict, list)):
+                    stack.append(v)
+        elif isinstance(value, list):
+            stack.extend(value)
+    return ""
+
+
+def _looks_like_identifier(name: str, source_id: str, pubkey: str) -> bool:
+    lowered = name.lower().lstrip("!")
+    identifiers = {
+        source_id.lower().lstrip("!"),
+        pubkey.lower().lstrip("!"),
+        pubkey[:12].lower().lstrip("!"),
+    }
+    if lowered in identifiers:
+        return True
+    try:
+        int(lowered, 16)
+        return len(lowered) >= 8
+    except ValueError:
+        return False
 
 
 def _build_raw_data(

--- a/src/decode/meshcore_event_adapter.py
+++ b/src/decode/meshcore_event_adapter.py
@@ -122,11 +122,27 @@ def _build_channel_message(
 def _build_advertisement(
     payload: dict, signal: Optional[SignalMetrics]
 ) -> Packet:
-    pubkey = payload.get("public_key", payload.get("pubkey", "unknown"))
+    pubkey = _first_payload_value(
+        payload,
+        "public_key",
+        "pubkey",
+        "pub_key",
+        "pubkey_prefix",
+        default="unknown",
+    )
     source_id = pubkey[:12] if len(pubkey) >= 12 else pubkey
+    name = _first_payload_value(
+        payload,
+        "adv_name",
+        "name",
+        "long_name",
+        "display_name",
+        default="",
+    )
+    display_name = name or source_id
     decoded = {
-        "long_name": payload.get("adv_name", source_id),
-        "short_name": payload.get("adv_name", source_id)[:4],
+        "long_name": display_name,
+        "short_name": display_name[:4],
         "public_key": pubkey,
         "advertisement": payload,
     }
@@ -145,6 +161,18 @@ def _build_advertisement(
         signal=signal,
         timestamp=_parse_timestamp(payload.get("timestamp")),
     )
+
+
+def _first_payload_value(payload: dict, *keys: str, default: str = "") -> str:
+    """Return the first non-empty string-ish value from a MeshCore event."""
+    for key in keys:
+        value = payload.get(key)
+        if value is None:
+            continue
+        value = str(value).strip()
+        if value:
+            return value
+    return default
 
 
 def _build_raw_data(

--- a/src/models/node.py
+++ b/src/models/node.py
@@ -37,7 +37,18 @@ class Node:
 
     @property
     def display_name(self) -> str:
-        return self.long_name or self.short_name or f"!{self.node_id}"
+        if self.long_name and not self._is_placeholder_name(self.long_name):
+            return self.long_name
+        if self.short_name and not self._is_placeholder_name(self.short_name):
+            return self.short_name
+        return f"!{self.node_id}"
+
+    def _is_placeholder_name(self, name: str) -> bool:
+        if self.protocol != "meshcore":
+            return False
+        lowered = name.lower().lstrip("!")
+        node_id = self.node_id.lower().lstrip("!")
+        return lowered == node_id or lowered == node_id[:4]
 
     def to_dict(self) -> dict:
         result = {

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -136,6 +136,7 @@ class DatabaseManager:
             logger.info("Migration: added rx_count column to messages table")
 
         await self._cleanup_cross_protocol_name_contamination()
+        await self._cleanup_meshcore_placeholder_names()
 
     async def _cleanup_cross_protocol_name_contamination(self) -> None:
         """Repair Meshtastic node rows whose long_name was overwritten by a
@@ -164,6 +165,30 @@ class DatabaseManager:
             logger.warning(
                 "Migration: cleared %d cross-protocol contaminated Meshtastic "
                 "node row(s); long_name will be repopulated on next NodeInfo",
+                cursor.rowcount,
+            )
+
+    async def _cleanup_meshcore_placeholder_names(self) -> None:
+        """Clear MeshCore rows that accidentally stored IDs as display names."""
+        cursor = await self._connection.execute(
+            """
+            UPDATE nodes
+            SET long_name = NULL,
+                short_name = CASE
+                    WHEN short_name IS NOT NULL
+                     AND LOWER(LTRIM(short_name, '!')) = LOWER(SUBSTR(LTRIM(node_id, '!'), 1, 4))
+                        THEN NULL
+                    ELSE short_name
+                END
+            WHERE protocol = 'meshcore'
+              AND long_name IS NOT NULL
+              AND LOWER(LTRIM(long_name, '!')) = LOWER(LTRIM(node_id, '!'))
+            """
+        )
+        if cursor.rowcount and cursor.rowcount > 0:
+            logger.warning(
+                "Migration: cleared %d MeshCore node placeholder name(s); "
+                "names will repopulate on the next valid advert",
                 cursor.rowcount,
             )
 

--- a/src/storage/node_repository.py
+++ b/src/storage/node_repository.py
@@ -27,7 +27,16 @@ class NodeRepository:
                 altitude, last_heard, first_seen, packet_count
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(node_id) DO UPDATE SET
-                long_name = COALESCE(excluded.long_name, nodes.long_name),
+                long_name = CASE
+                    WHEN excluded.long_name IS NULL OR excluded.long_name = ''
+                        THEN nodes.long_name
+                    WHEN nodes.long_name IS NULL OR nodes.long_name = ''
+                        THEN excluded.long_name
+                    WHEN nodes.protocol = 'meshcore'
+                         AND LOWER(nodes.long_name) = LOWER(nodes.node_id)
+                        THEN excluded.long_name
+                    ELSE nodes.long_name
+                END,
                 short_name = COALESCE(excluded.short_name, nodes.short_name),
                 hardware_model = COALESCE(excluded.hardware_model, nodes.hardware_model),
                 firmware_version = COALESCE(excluded.firmware_version, nodes.firmware_version),

--- a/tests/test_database_migration.py
+++ b/tests/test_database_migration.py
@@ -179,6 +179,38 @@ class TestCrossProtocolNameCleanup(unittest.TestCase):
             os.unlink(db_path)
 
 
+class TestMeshCorePlaceholderNameCleanup(unittest.TestCase):
+    def test_runs_during_connect(self):
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        import os
+        os.close(fd)
+        try:
+            db = DatabaseManager(db_path)
+            _run(db.connect())
+            now = datetime.now(timezone.utc).isoformat()
+            _run(db.execute(
+                "INSERT INTO nodes (node_id, long_name, short_name, protocol, "
+                "last_heard, first_seen) VALUES "
+                "('e34ef4172778', 'e34ef4172778', 'e34e', 'meshcore', ?, ?)",
+                (now, now),
+            ))
+            _run(db.commit())
+            _run(db.disconnect())
+
+            db2 = DatabaseManager(db_path)
+            _run(db2.connect())
+            row = _run(db2.fetch_one(
+                "SELECT long_name, short_name FROM nodes WHERE node_id = ?",
+                ("e34ef4172778",),
+            ))
+            self.assertIsNotNone(row)
+            self.assertIsNone(row["long_name"])
+            self.assertIsNone(row["short_name"])
+            _run(db2.disconnect())
+        finally:
+            os.unlink(db_path)
+
+
 class TestRelayNodeMigration(unittest.TestCase):
     """Validate the ``packets.relay_node`` ALTER TABLE migration.
 

--- a/tests/test_meshcore_contact_enrichment.py
+++ b/tests/test_meshcore_contact_enrichment.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from src.api.meshcore_contacts import sync_meshcore_contacts_to_nodes
+from src.models.node import Node
+from src.storage.database import DatabaseManager
+from src.storage.node_repository import NodeRepository
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _Coord:
+    def __init__(self, repo: NodeRepository):
+        self.node_repo = repo
+
+
+class _MeshCoreTx:
+    connected = True
+
+    async def get_contacts(self):
+        return [{
+            "public_key": "e34ef4172778aaaabbbbcccc",
+            "name": "Ridge Repeater",
+        }]
+
+
+class TestMeshCoreContactEnrichment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db = DatabaseManager(":memory:")
+        _run(self.db.connect())
+        self.repo = NodeRepository(self.db)
+        self.coord = _Coord(self.repo)
+
+    def tearDown(self) -> None:
+        _run(self.db.disconnect())
+
+    def test_contact_name_updates_matching_meshcore_node(self):
+        _run(self.repo.upsert(Node(
+            node_id="e34ef4172778",
+            protocol="meshcore",
+        )))
+
+        updated = _run(sync_meshcore_contacts_to_nodes(
+            self.coord,
+            _MeshCoreTx(),
+            "e34ef4172778",
+        ))
+
+        node = _run(self.repo.get_by_id("e34ef4172778"))
+        self.assertEqual(updated, 1)
+        self.assertEqual(node.long_name, "Ridge Repeater")
+        self.assertEqual(node.short_name, "Ridg")
+        self.assertEqual(node.display_name, "Ridge Repeater")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meshcore_usb.py
+++ b/tests/test_meshcore_usb.py
@@ -119,6 +119,29 @@ class TestMeshcoreEventAdapter(unittest.TestCase):
         self.assertEqual(pkt.decoded_payload["long_name"], "AliasNode")
         self.assertEqual(pkt.decoded_payload["short_name"], "Alia")
 
+    def test_advertisement_accepts_nested_name_alias(self):
+        raw = self._make_envelope("advertisement", {
+            "public_key": "abcdef1234567890abcdef",
+            "advert": {"longName": "NestedRepeater"},
+        })
+        pkt = adapt_event(raw)
+        self.assertIsNotNone(pkt)
+        self.assertEqual(pkt.packet_type, PacketType.NODEINFO)
+        self.assertEqual(pkt.source_id, "abcdef123456")
+        self.assertEqual(pkt.decoded_payload["long_name"], "NestedRepeater")
+        self.assertEqual(pkt.decoded_payload["short_name"], "Nest")
+
+    def test_advertisement_without_real_name_does_not_store_id_as_name(self):
+        raw = self._make_envelope("advertisement", {
+            "public_key": "abcdef1234567890abcdef",
+        })
+        pkt = adapt_event(raw)
+        self.assertIsNotNone(pkt)
+        self.assertEqual(pkt.packet_type, PacketType.NODEINFO)
+        self.assertEqual(pkt.source_id, "abcdef123456")
+        self.assertNotIn("long_name", pkt.decoded_payload)
+        self.assertNotIn("short_name", pkt.decoded_payload)
+
     def test_advertisement_no_coords(self):
         raw = self._make_envelope("advertisement", {
             "public_key": "abcdef1234567890abcdef",

--- a/tests/test_meshcore_usb.py
+++ b/tests/test_meshcore_usb.py
@@ -107,6 +107,18 @@ class TestMeshcoreEventAdapter(unittest.TestCase):
         self.assertAlmostEqual(pkt.decoded_payload["latitude"], 43.9091)
         self.assertAlmostEqual(pkt.decoded_payload["longitude"], -72.2207)
 
+    def test_advertisement_accepts_name_alias(self):
+        raw = self._make_envelope("advertisement", {
+            "public_key": "abcdef1234567890abcdef",
+            "name": "AliasNode",
+        })
+        pkt = adapt_event(raw)
+        self.assertIsNotNone(pkt)
+        self.assertEqual(pkt.packet_type, PacketType.NODEINFO)
+        self.assertEqual(pkt.source_id, "abcdef123456")
+        self.assertEqual(pkt.decoded_payload["long_name"], "AliasNode")
+        self.assertEqual(pkt.decoded_payload["short_name"], "Alia")
+
     def test_advertisement_no_coords(self):
         raw = self._make_envelope("advertisement", {
             "public_key": "abcdef1234567890abcdef",

--- a/tests/test_node_repository.py
+++ b/tests/test_node_repository.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from src.models.node import Node
+from src.storage.database import DatabaseManager
+from src.storage.node_repository import NodeRepository
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TestNodeRepository(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db = DatabaseManager(":memory:")
+        _run(self.db.connect())
+        self.repo = NodeRepository(self.db)
+
+    def tearDown(self) -> None:
+        _run(self.db.disconnect())
+
+    def test_meshcore_pubkey_placeholder_name_is_replaced(self):
+        node_id = "abcdef123456"
+        _run(self.repo.upsert(
+            Node(
+                node_id=node_id,
+                long_name=node_id,
+                short_name=node_id[:4],
+                protocol="meshcore",
+            )
+        ))
+
+        _run(self.repo.upsert(
+            Node(
+                node_id=node_id,
+                long_name="Trail Relay",
+                short_name="Trai",
+                protocol="meshcore",
+            )
+        ))
+
+        node = _run(self.repo.get_by_id(node_id))
+        self.assertIsNotNone(node)
+        self.assertEqual(node.long_name, "Trail Relay")
+
+    def test_existing_real_name_is_kept(self):
+        node_id = "abcdef123456"
+        _run(self.repo.upsert(
+            Node(
+                node_id=node_id,
+                long_name="Trail Relay",
+                protocol="meshcore",
+            )
+        ))
+
+        _run(self.repo.upsert(
+            Node(
+                node_id=node_id,
+                long_name="Other Name",
+                protocol="meshcore",
+            )
+        ))
+
+        node = _run(self.repo.get_by_id(node_id))
+        self.assertIsNotNone(node)
+        self.assertEqual(node.long_name, "Trail Relay")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_node_repository.py
+++ b/tests/test_node_repository.py
@@ -71,6 +71,16 @@ class TestNodeRepository(unittest.TestCase):
         self.assertIsNotNone(node)
         self.assertEqual(node.long_name, "Trail Relay")
 
+    def test_meshcore_display_name_ignores_id_placeholder(self):
+        node = Node(
+            node_id="abcdef123456",
+            long_name="abcdef123456",
+            short_name="abcd",
+            protocol="meshcore",
+        )
+
+        self.assertEqual(node.display_name, "!abcdef123456")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fix MeshCore discovered nodes showing public-key prefixes instead of friendly repeater names.

## Why

ID's are hard to read and the node names make it much easier

## Type

- [X] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] UI
- [ ] Installer
- [ ] Region support
- [ ] Hardware change

## Testing

How tested?

- [ ] Local only
- [X] Tested on hardware
- [X] Dashboard tested
- [ ] Docs only
- [ ] UI only

**Hardware:**

- Pi: RAK Hotspot V2
- Concentrator:
- Node/radio: Heltec V4
- Region:
- OS:

## Impact

Does this affect:

- [X] Parsing
- [ ] Relay
- [ ] TX
- [ ] Radio driver
- [ ] Region logic
- [ ] UI only
- [ ] Installer only

Notes:

## AI-assisted?

- [ ] No
- [X] Yes

If yes, how:
Expanded MeshCore advert parsing to recognize more name fields, including camelCase aliases and nested advert payloads.
Prevented MeshCore adverts without a real name from storing the node ID/pubkey prefix as long_name.
Added display-name fallback logic so MeshCore placeholder names do not masquerade as friendly names.
Added a startup DB cleanup for existing MeshCore rows where long_name was accidentally saved as the node ID.
Added MeshCore contact-list enrichment:
On startup, sync discovered MeshCore node rows from the companion contact list.
After MeshCore packets, refresh matching node names by public-key prefix.
Added regression tests for:
Advert name aliases.
Nested advert name fields.
Missing advert names not becoming node names.
Placeholder MeshCore names being ignored/replaced.
Startup cleanup of stale placeholder names.
Contact-list enrichment of a discovered MeshCore node.
Files Changed

src/decode/meshcore_event_adapter.py
src/models/node.py
src/storage/database.py
src/api/server.py
src/api/meshcore_contacts.py
tests/test_meshcore_usb.py
tests/test_node_repository.py
tests/test_database_migration.py
tests/test_meshcore_contact_enrichment.py