### PR TITLE
feat: add CPU load average to device metrics and dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -310,6 +310,11 @@
                             <div class="stat-card__label">CPU Temp</div>
                             <div class="stat-card__value" id="stat-temp-val">--</div>
                         </div>
+                        <div class="stat-card stat-card--system" id="stat-load">
+                            <div class="stat-card__label">Load Avg</div>
+                            <div class="stat-card__value" id="stat-load-val">--</div>
+                            <div class="stat-card__sub" id="stat-load-sub"></div>
+                        </div>
                     </section>
 
                     <div class="dashboard__main">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -381,6 +381,14 @@ async function _updateStats() {
             _setText('stat-disk-val', `${metrics.disk_percent}%`);
             _setText('stat-disk-sub', `${metrics.disk_used_gb} / ${metrics.disk_total_gb} GB`);
             _setText('stat-temp-val', metrics.cpu_temp_c != null ? `${metrics.cpu_temp_c}°C` : 'N/A');
+            if (Array.isArray(metrics.load_avg)) {
+                const [m1, m5, m15] = metrics.load_avg;
+                _setText('stat-load-val', m1.toFixed(2));
+                _setText('stat-load-sub', `5m ${m5.toFixed(2)} · 15m ${m15.toFixed(2)}`);
+            } else {
+                _setText('stat-load-val', 'N/A');
+                _setText('stat-load-sub', '');
+            }
         }
     } catch (e) {
         console.error('Failed to update stats:', e);

--- a/src/api/routes/system_metrics.py
+++ b/src/api/routes/system_metrics.py
@@ -19,6 +19,15 @@ def _read_cpu_temp() -> float | None:
         return None
 
 
+def _read_load_avg() -> tuple[float, float, float] | None:
+    """Read the 1/5/15-minute load averages from /proc/loadavg (Linux)."""
+    try:
+        fields = Path("/proc/loadavg").read_text().split()
+        return float(fields[0]), float(fields[1]), float(fields[2])
+    except (FileNotFoundError, ValueError, OSError, IndexError):
+        return None
+
+
 def _read_uptime_seconds() -> float:
     """Read system uptime from /proc/uptime (Linux)."""
     try:
@@ -34,6 +43,7 @@ async def system_metrics():
     mem = psutil.virtual_memory()
     disk = shutil.disk_usage("/")
     cpu_temp = _read_cpu_temp()
+    load_avg = _read_load_avg()
 
     return {
         "cpu_percent": psutil.cpu_percent(interval=0.5),
@@ -44,5 +54,6 @@ async def system_metrics():
         "disk_used_gb": round(disk.used / (1024 ** 3), 1),
         "disk_total_gb": round(disk.total / (1024 ** 3), 1),
         "cpu_temp_c": round(cpu_temp, 1) if cpu_temp is not None else None,
+        "load_avg": [round(v, 2) for v in load_avg] if load_avg is not None else None,
         "system_uptime_seconds": int(_read_uptime_seconds()),
     }

--- a/tests/test_system_metrics_load_avg.py
+++ b/tests/test_system_metrics_load_avg.py
@@ -1,0 +1,32 @@
+"""Parsing tests for the /proc/loadavg reader in system metrics."""
+
+import unittest
+from unittest.mock import patch
+
+from src.api.routes import system_metrics
+
+
+class TestReadLoadAvg(unittest.TestCase):
+    def test_parses_three_averages(self):
+        with patch.object(
+            system_metrics.Path,
+            "read_text",
+            return_value="0.42 0.55 0.61 1/234 5678",
+        ):
+            self.assertEqual(system_metrics._read_load_avg(), (0.42, 0.55, 0.61))
+
+    def test_returns_none_when_unavailable(self):
+        with patch.object(
+            system_metrics.Path, "read_text", side_effect=FileNotFoundError
+        ):
+            self.assertIsNone(system_metrics._read_load_avg())
+
+    def test_returns_none_on_malformed_content(self):
+        with patch.object(
+            system_metrics.Path, "read_text", return_value="garbage"
+        ):
+            self.assertIsNone(system_metrics._read_load_avg())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the system 1/5/15-minute load average to the device metrics endpoint and
surfaces it as a new "Load Avg" card on the dashboard system stats row.

- Backend: new `_read_load_avg()` helper reads `/proc/loadavg`; `GET /api/device/metrics`
  now returns `"load_avg": [1m, 5m, 15m]` (or `null` on non-Linux hosts).
- Frontend: new `Load Avg` stat card showing the 1-min value with `5m · 15m` sub-line,
  falling back to `N/A` when unavailable — mirrors the existing CPU Temp card.
- Tests: 3 unit tests covering valid parse, missing file, and malformed content.

## Why

Load average is a standard, low-overhead health signal that complements the existing
CPU%, RAM, disk, and temperature stats — useful for spotting sustained load on
resource-constrained Pi devices without opening a shell.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [x] UI
- [ ] Installer
- [ ] Region support
- [ ] Hardware change

## Testing

Added unit tests for the `/proc/loadavg` parser (pass via `python -m unittest`).
Backend/JS changes follow the existing metrics + stat-card patterns. Not yet run on
Pi hardware; load values render `N/A` on Windows since `/proc/loadavg` is absent there.

- [x] Local only
- [ ] Tested on hardware
- [ ] Dashboard tested
- [ ] Docs only
- [ ] UI only

**Hardware:**

- Pi: not tested on hardware
- Concentrator: n/a
- Node/radio: n/a
- Region: n/a
- OS: developed on Windows 11 (Linux-only code path verified by unit tests)

## Impact

Does this affect:

- [ ] Parsing
- [ ] Relay
- [ ] TX
- [ ] Radio driver
- [ ] Region logic
- [x] UI only
- [ ] Installer only

Notes: Additive only — one new key on `/api/device/metrics` and one new dashboard
card. No changes to existing metric fields, packet handling, or radio paths.

## AI-assisted?

- [ ] No
- [x] Yes

If yes, how: Reviewed works and tested with Claude Code (Anthropic). Author wrote main cod, reviewed bug fixes, and understands all changes being made.

