### PR TITLE
feat(config): warn on unknown local.yaml keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Queued for the next version bump.
 
+- **Config: warn on unknown `local.yaml` keys.** The loader (`src/config.py`) now logs a single `WARNING` listing any config keys it could not apply: a misspelled field (`tx_powr_dbm`), a stray nested key, or a whole mistyped section (`transmt:`), instead of silently dropping them. Behaviour is otherwise unchanged: unknown keys are still ignored, known keys still merge as before. Helps diagnose "I set it in `local.yaml` but nothing happened". Adds `tests/test_config_loader.py` covering the merge path and the warning.
+
 - **MQTT broker TLS (deferred).** Transport TLS (`mqtts`, CA bundle, cert validation) is not implemented on `mqtt_publisher.py` (plain TCP only). Planned for the same release vehicle as **Meshtastic PKI**. Until then use plain port 1883 or a LAN broker without TLS.
 
 ### v0.7.5 (May 2026)

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import os
 import sys
 from dataclasses import dataclass, field
@@ -10,6 +11,8 @@ from typing import Optional
 import yaml
 
 from src.version import __version__
+
+logger = logging.getLogger(__name__)
 
 
 # Band-start frequencies (MHz) for the Meshtastic slot formula
@@ -325,6 +328,25 @@ def _merge_dataclass(instance, overrides: dict):
             setattr(instance, key, value)
 
 
+def _collect_unknown_keys(instance, overrides: dict, prefix: str = "") -> list[str]:
+    """Return dotted paths of override keys with no matching dataclass field.
+
+    Mirrors the descent rules in :func:`_merge_dataclass`: it only recurses
+    into a nested dataclass (e.g. ``transmit.nodeinfo``), so user-supplied
+    mapping fields such as ``meshtastic.channel_keys`` are treated as opaque
+    values rather than scanned for "unknown" keys.
+    """
+    unknown: list[str] = []
+    for key, value in overrides.items():
+        if not hasattr(instance, key):
+            unknown.append(f"{prefix}{key}")
+            continue
+        current = getattr(instance, key)
+        if dataclasses.is_dataclass(current) and isinstance(value, dict):
+            unknown.extend(_collect_unknown_keys(current, value, f"{prefix}{key}."))
+    return unknown
+
+
 def _apply_yaml(cfg: AppConfig, path: Path) -> None:
     """Merge a single YAML file into an existing AppConfig."""
     if not path.exists():
@@ -332,6 +354,10 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
 
     with open(path, "r") as fh:
         raw = yaml.safe_load(fh) or {}
+
+    if not isinstance(raw, dict):
+        logger.warning("Ignoring %s: top-level YAML is not a mapping.", path)
+        return
 
     section_map = {
         "radio": cfg.radio,
@@ -349,9 +375,26 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
         "location": cfg.location,
     }
 
-    for section_name, section_instance in section_map.items():
-        if section_name in raw:
-            _merge_dataclass(section_instance, raw[section_name])
+    unknown_keys: list[str] = []
+    for section_name, section_value in raw.items():
+        section_instance = section_map.get(section_name)
+        if section_instance is None:
+            unknown_keys.append(section_name)
+            continue
+        _merge_dataclass(section_instance, section_value)
+        if isinstance(section_value, dict):
+            unknown_keys.extend(
+                _collect_unknown_keys(section_instance, section_value, f"{section_name}.")
+            )
+
+    if unknown_keys:
+        logger.warning(
+            "Ignoring %d unknown config key(s) in %s: %s. "
+            "These were not applied -- check for typos against the documented schema.",
+            len(unknown_keys),
+            path,
+            ", ".join(sorted(unknown_keys)),
+        )
 
 
 _VALID_CONFIG_EXTENSIONS = {".yaml", ".yml"}

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,148 @@
+"""Tests for the two-layer YAML config loader in ``src.config``.
+
+Focuses on the merge path and the unknown-key warning: a typo in
+``local.yaml`` (``tx_powr_dbm`` for ``tx_power_dbm``, a misspelled
+section name, a stray nested key) is silently dropped by the
+dataclass merge, so the loader now logs a single warning listing the
+ignored keys to help operators debug "my setting did nothing".
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.config import (
+    AppConfig,
+    _apply_yaml,
+    _collect_unknown_keys,
+    load_config,
+)
+
+
+class CollectUnknownKeysTest(unittest.TestCase):
+    def test_flat_unknown_key_is_reported(self):
+        cfg = AppConfig()
+        unknown = _collect_unknown_keys(
+            cfg.transmit, {"tx_power_dbm": 20, "tx_powr_dbm": 99}
+        )
+        self.assertEqual(unknown, ["tx_powr_dbm"])
+
+    def test_all_known_keys_report_nothing(self):
+        cfg = AppConfig()
+        unknown = _collect_unknown_keys(
+            cfg.transmit, {"enabled": True, "tx_power_dbm": 20, "hop_limit": 5}
+        )
+        self.assertEqual(unknown, [])
+
+    def test_nested_dataclass_is_recursed_with_dotted_path(self):
+        cfg = AppConfig()
+        unknown = _collect_unknown_keys(
+            cfg.transmit,
+            {"nodeinfo": {"interval_minutes": 60, "intrval_minutes": 60}},
+        )
+        self.assertEqual(unknown, ["nodeinfo.intrval_minutes"])
+
+    def test_mapping_field_values_are_not_scanned(self):
+        # meshtastic.channel_keys is a user-populated dict[str, str]; its
+        # arbitrary channel names must not be flagged as unknown keys.
+        cfg = AppConfig()
+        unknown = _collect_unknown_keys(
+            cfg.meshtastic,
+            {"channel_keys": {"Secret": "AbCd==", "AnotherChan": "EfGh=="}},
+        )
+        self.assertEqual(unknown, [])
+
+
+class ApplyYamlUnknownKeyTest(unittest.TestCase):
+    def _write(self, text: str) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        )
+        tmp.write(text)
+        tmp.close()
+        path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
+    def test_unknown_key_not_applied_and_warns(self):
+        cfg = AppConfig()
+        path = self._write(
+            "transmit:\n"
+            "  tx_power_dbm: 20\n"
+            "  tx_powr_dbm: 99\n"
+        )
+        with self.assertLogs("src.config", level="WARNING") as captured:
+            _apply_yaml(cfg, path)
+
+        # Valid key applied; typo dropped (stays at the dataclass default).
+        self.assertEqual(cfg.transmit.tx_power_dbm, 20)
+        self.assertFalse(hasattr(cfg.transmit, "tx_powr_dbm"))
+        joined = "\n".join(captured.output)
+        self.assertIn("transmit.tx_powr_dbm", joined)
+        self.assertIn(str(path), joined)
+
+    def test_unknown_top_level_section_is_reported(self):
+        cfg = AppConfig()
+        path = self._write("transmt:\n  enabled: true\n")
+        with self.assertLogs("src.config", level="WARNING") as captured:
+            _apply_yaml(cfg, path)
+        # The whole misspelled section is ignored, not silently swallowed.
+        self.assertFalse(cfg.transmit.enabled)
+        self.assertIn("transmt", "\n".join(captured.output))
+
+    def test_non_mapping_top_level_is_ignored_not_crashed(self):
+        cfg = AppConfig()
+        path = self._write("- just\n- a\n- list\n")
+        with self.assertLogs("src.config", level="WARNING"):
+            _apply_yaml(cfg, path)  # must not raise
+        # Defaults left intact.
+        self.assertEqual(cfg.radio.region, "US")
+
+    def test_clean_config_emits_no_warning(self):
+        cfg = AppConfig()
+        path = self._write(
+            "radio:\n"
+            "  region: EU_868\n"
+            "transmit:\n"
+            "  enabled: true\n"
+            "  nodeinfo:\n"
+            "    interval_minutes: 60\n"
+        )
+        with self.assertNoLogs("src.config", level="WARNING"):
+            _apply_yaml(cfg, path)
+
+        self.assertEqual(cfg.radio.region, "EU_868")
+        self.assertTrue(cfg.transmit.enabled)
+        self.assertEqual(cfg.transmit.nodeinfo.interval_minutes, 60)
+
+
+class LoadConfigIntegrationTest(unittest.TestCase):
+    def test_typo_in_local_yaml_is_warned_and_ignored(self):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        )
+        tmp.write("transmit:\n  hop_limit: 7\n  hoplimit: 99\n")
+        tmp.close()
+        path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+
+        old = os.environ.get("CONCENTRATOR_CONFIG")
+        os.environ["CONCENTRATOR_CONFIG"] = str(path)
+        try:
+            with self.assertLogs("src.config", level="WARNING") as captured:
+                cfg = load_config()
+        finally:
+            if old is None:
+                os.environ.pop("CONCENTRATOR_CONFIG", None)
+            else:
+                os.environ["CONCENTRATOR_CONFIG"] = old
+
+        self.assertEqual(cfg.transmit.hop_limit, 7)
+        self.assertIn("transmit.hoplimit", "\n".join(captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The config loader silently dropped any unknown key in `local.yaml`. The
dataclass merge (`_merge_dataclass`: `if not hasattr: continue`) means a
typo like `tx_powr_dbm` instead of `tx_power_dbm`, a stray nested key, or a
whole misspelled section (`transmt:`) just does nothing — with no signal to
the operator. `_apply_yaml` now collects every unapplied key (as dotted
paths, recursing only into nested dataclasses so user-populated maps like
`meshtastic.channel_keys` aren't false-flagged) and logs a single WARNING
listing them plus the file path. A non-mapping top-level YAML is now warned
and skipped instead of relying on incidental no-crash behaviour.

Adds `tests/test_config_loader.py` — first direct coverage of the loader.

## Why

Recurring "I set it in `local.yaml` but nothing happened" footgun. A
misspelled field gives zero feedback today, so operators burn time
debugging a setting that was never applied. Surfacing it as one log line
turns a silent failure into an obvious one. This is a pure config-validation
+ logging change, which CONTRIBUTING lists as a safe area to contribute.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] UI
- [ ] Installer
- [ ] Region support
- [ ] Hardware change

## Testing

`python -m pytest tests/test_config_loader.py tests/test_radio_frequency_resolver.py`
→ 24 passed. `ruff check src/config.py tests/test_config_loader.py` → clean.
New tests cover: flat/nested unknown keys, dotted nested paths, the
mapping-field exemption, an unknown top-level section, the non-mapping
guard, and a `load_config` integration case. Behaviour is otherwise
unchanged — unknown keys are still ignored, known keys still merge as before.

- [x] Local only
- [ ] Tested on hardware
- [ ] Dashboard tested
- [ ] Docs only
- [ ] UI only

**Hardware:**

- Pi: n/a (config-layer change, no hardware exercised)
- Concentrator: n/a
- Node/radio: n/a
- Region: n/a
- OS: developed on Windows; logic is pure Python/stdlib + PyYAML, CI runs Python 3.12

## Impact

Does this affect:

- [ ] Parsing
- [ ] Relay
- [ ] TX
- [ ] Radio driver
- [ ] Region logic
- [ ] UI only
- [ ] Installer only

Notes: None of the above. Touches only `src/config.py` (YAML→dataclass merge)
and adds a test. No RF/radio/concentrator/region code changed; the only new
runtime behaviour is a WARNING log line. Known keys are applied exactly as
before.

## AI-assisted?

- [ ] No
- [x] Yes

If yes, how: Code written by author of commit and PR, reviewed and tested by Claude Code (Anthropic).
