### PR TITLE
docs: WisMesh Node (RAK6421) discovery on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Everything is managed from a browser dashboard: full chat with channels and DMs,
 
 **Dual-protocol MQTT gateway.** Publish captured packets to community MQTT brokers and Home Assistant. Dual-protocol: Meshtastic (protobuf) and MeshCore (JSON) from a single device. Two-gate privacy model ensures private channel data never leaks. Optional JSON publishing, HA auto-discovery, and configurable location precision.
 
-**Auto-detect hardware.** RAK Hotspot V2, SenseCap M1, and Syncrobit Chameleon (SX1302) supported; carrier board may show as generic SX1302/Pi during setup. MeshCore USB companions auto-detected on `/dev/ttyUSB*` and `/dev/ttyACM*`.
+**Auto-detect hardware.** RAK Hotspot V2, SenseCap M1, and Syncrobit Chameleon (SX1302) supported; carrier board may show as generic SX1302/Pi during setup. **WisMesh Node** (RAK6421 Pi HAT + WisBlock SX1262, experimental) is documented on `main` and installs from branch `feat/wismesh-hat` until v0.7.6 merges. MeshCore USB companions auto-detected on `/dev/ttyUSB*` and `/dev/ttyACM*`.
 
 ---
 
@@ -129,6 +129,23 @@ aarch64 Raspbian 13 (Trixie) with live Meshtastic RX/TX.
 *\*Helium's surplus means RAK2287 concentrators and Pi HATs go for ~$20 combined on eBay.*
 
 **Assembly:** Seat the RAK2287 on the Pi HAT, mount the HAT on the Pi GPIO header, connect the antenna. Always connect the antenna before powering on.
+
+### Option E: WisMesh Node (RAK6421 HAT, experimental)
+
+The [RAK WisMesh Pi Node](https://store.rakwireless.com/products/wismesh-pi-node) is a Pi HAT with a **WisBlock SX1262** LoRa module (RAK13300 standard or **RAK13302 1W** with PA). Meshpoint drives RF through **meshtasticd** (Portduino), not the SX1302 concentrator path used by Options A–D.
+
+**Status:** User-facing docs are on **`main`** now. The installer, dashboard, and capture bridge are on branch **`feat/wismesh-hat`** until they ship in **v0.7.6**. Gateway users should stay on **`main`**.
+
+```bash
+cd /opt/meshpoint
+sudo git fetch origin
+sudo git checkout feat/wismesh-hat
+sudo git pull
+sudo ./scripts/install.sh --platform node
+sudo meshpoint setup
+```
+
+> **Guides:** [WisMesh branch overview](docs/plans/WISMESH-BRANCH.md), [Gateway ↔ Node migration](docs/MIGRATE-GATEWAY-TO-NODE.md), [Hardware Matrix](docs/HARDWARE-MATRIX.md#wismesh-node-rak6421-hat-experimental).
 
 ### Optional: MeshCore USB Companion
 
@@ -259,7 +276,9 @@ Start with the doc that matches what you are trying to do.
 
 **Setup and configuration**
 - **[Onboarding Guide](docs/ONBOARDING.md):** step-by-step from empty Pi to running Meshpoint
-- **[Hardware Matrix](docs/HARDWARE-MATRIX.md):** RAK V2 vs SenseCap M1 vs DIY, MeshCore companion radios, antennas, what's not supported
+- **[Hardware Matrix](docs/HARDWARE-MATRIX.md):** RAK V2 vs SenseCap M1 vs DIY, WisMesh Node (experimental), MeshCore companion radios, antennas, what's not supported
+- **[WisMesh Node (experimental)](docs/plans/WISMESH-BRANCH.md):** RAK6421 HAT, meshtasticd, branch install until v0.7.6
+- **[Gateway ↔ Node migration](docs/MIGRATE-GATEWAY-TO-NODE.md):** switch between concentrator Gateway and WisMesh Node platforms
 - **[Configuration Guide](docs/CONFIGURATION.md):** all config options, private channels, relay, upstream, MQTT, radio tuning
 - **[Radio Config Explained](docs/RADIO-CONFIG-EXPLAINED.md):** the "why" behind region, spreading factor, bandwidth, custom slots, Part 15 awareness
 - **[MQTT and Meshradar](docs/MQTT-AND-MESHRADAR.md):** the two cloud paths side-by-side, what data flows where, privacy posture

--- a/docs/HARDWARE-MATRIX.md
+++ b/docs/HARDWARE-MATRIX.md
@@ -56,6 +56,7 @@ If your deployment cannot guarantee clean shutdowns, either:
 | You want easiest reflash (back panel access) | RAK Hotspot V2 (4 bottom screws) |
 | You want PoE and a sealed outdoor-style enclosure | Syncrobit Chameleon (after eMMC reflash) |
 | You already have a Chameleon and a CM4 USB carrier | Repurpose with [Syncrobit Chameleon guide](SYNCROBIT-CHAMELEON.md) |
+| You have a RAK WisMesh Pi Node HAT (RAK6421) | [WisMesh Node (experimental)](#wismesh-node-rak6421-hat-experimental) on branch `feat/wismesh-hat` |
 
 ### Syncrobit Chameleon notes
 
@@ -74,6 +75,28 @@ to restore vendor software.
 supply enough current for CM4 + concentrator (plan for up to ~2-3 A at 5 V
 equivalent). Prefer `sudo poweroff` before removing PoE to avoid SPI latch
 (see below).
+
+---
+
+## WisMesh Node (RAK6421 HAT, experimental)
+
+Meshpoint **Node** platform for the [RAK WisMesh Pi Node](https://store.rakwireless.com/products/wismesh-pi-node): Pi 4 + **RAK6421** HAT + WisBlock **SX1262** (slot 1). RF is owned by **meshtasticd** (single-channel Meshtastic participant), not the SX1302 concentrator stack used elsewhere in this matrix.
+
+| | WisMesh Node (RAK6421) |
+|---|---|
+| **Host** | Pi 4 (SD), 64-bit OS |
+| **Radio** | WisBlock RAK13300 (~22 dBm) or **RAK13302 1W** (PA, default preset) |
+| **RF stack** | meshtasticd → TCP Phone API (`:4403`) → Meshpoint bridge |
+| **RX channels** | One LoRa channel at a time (modem preset), not 8-ch SF7–SF12 parallel |
+| **TX** | Yes (via meshtasticd) |
+| **Meshpoint role** | Observer + participant on Meshtastic; same dashboard chat and upstream as Gateway |
+| **MeshCore** | Optional USB companion (same as Gateway); concentrator-free |
+
+**Docs on `main`:** this section, [README > Option E](../README.md#option-e-wismesh-node-rak6421-hat-experimental), [Onboarding](ONBOARDING.md), [Migrate Gateway ↔ Node](MIGRATE-GATEWAY-TO-NODE.md).
+
+**Software today:** branch **`feat/wismesh-hat`** (`install.sh --platform node`). Planned merge: **v0.7.6** on `main`. Full architecture and dashboard behavior: [`docs/plans/WISMESH-BRANCH.md`](plans/WISMESH-BRANCH.md).
+
+**Do not** run Gateway `install.sh` on a Pi that only has the WisMesh HAT (no SX1302). The setup wizard and `chip_id` probe expect a concentrator on Gateway installs.
 
 ---
 

--- a/docs/MIGRATE-GATEWAY-TO-NODE.md
+++ b/docs/MIGRATE-GATEWAY-TO-NODE.md
@@ -1,0 +1,77 @@
+# Migrating between Gateway and Node platforms
+
+Meshpoint supports two RF backends on Raspberry Pi hardware:
+
+| Platform | Hardware | RF owner | `capture.sources` |
+|----------|----------|----------|-------------------|
+| **Gateway** | SX1302/SX1303 concentrator (RAK V2, SenseCap M1, DIY) | Meshpoint HAL | `concentrator` |
+| **Node** | WisMesh Pi HAT (RAK6421) + WisBlock SX1262 | **meshtasticd** | `meshtasticd` |
+
+On **Node** platforms, meshtasticd must be running **before** Meshpoint starts. The installer configures systemd ordering automatically.
+
+## WisMesh Node (fresh install)
+
+Use the long-lived branch documented in [`docs/plans/WISMESH-BRANCH.md`](plans/WISMESH-BRANCH.md):
+
+```bash
+cd /opt/meshpoint
+sudo git fetch origin
+sudo git checkout feat/wismesh-hat
+sudo git pull
+sudo ./scripts/install.sh --platform node
+sudo meshpoint setup
+```
+
+The wizard detects the RAK6421 HAT and writes `device.platform: node` plus `capture.sources: [meshtasticd]`.
+
+## Switch an existing Gateway to Node
+
+Only do this when the Pi actually has a WisMesh HAT (not an SX1302 concentrator).
+
+```bash
+cd /opt/meshpoint
+sudo git checkout feat/wismesh-hat
+sudo git pull
+sudo meshpoint migrate-platform --to node
+sudo ./scripts/install.sh --platform node
+sudo systemctl restart meshtasticd meshpoint
+```
+
+## Switch Node back to Gateway
+
+When you replace the WisMesh HAT with an SX1302 concentrator HAT:
+
+```bash
+cd /opt/meshpoint
+sudo meshpoint migrate-platform --to gateway
+sudo ./scripts/install.sh --platform gateway
+sudo systemctl restart meshpoint
+```
+
+Re-run `sudo meshpoint setup` if capture sources or region changed.
+
+## Verify meshtasticd (Node only)
+
+```bash
+systemctl status meshtasticd
+/opt/meshpoint/venv/bin/meshtastic --host localhost:4403 --info
+journalctl -u meshpoint -n 50 --no-pager
+```
+
+Look for `meshtasticd bridge connected to 127.0.0.1:4403` and `Meshtastic DM identity:` in the Meshpoint logs.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| meshtasticd crash: blank MAC | Ensure `/etc/meshtasticd/config.yaml` has `General.MACAddressSource: eth0` (or `wlan0`) |
+| meshtasticd crash: no preset | Re-run `sudo ./scripts/install_meshtasticd.sh` (installs bundled 13302 preset) |
+| TX power ~22 dBm on RAK13302 1W module | 13300 preset or PA not powered | `meshtastic --host localhost:4403 --info` should show `txPower=30` and preset `13302` |
+| Meshpoint cannot connect to 4403 | Start meshtasticd first: `sudo systemctl restart meshtasticd` then `sudo systemctl restart meshpoint` |
+| Dashboard Apply fails at install.sh | Git may still be current while install failed. Run `sudo dpkg --configure -a`, then Apply again or `sudo bash scripts/install.sh` + restart |
+| Wrong platform detected | Override with `sudo ./scripts/install.sh --platform node` or edit `device.platform` in `local.yaml` |
+| OTA packets in logs then silence | Restart both services; do not run `meshtastic --host` while Meshpoint is up (single TCP client) |
+| Phone DM delivered but not on dashboard | meshtasticd node id must match DM destination; see `Meshtastic DM identity` in logs. Remove stale `transmit.node_id` if it disagrees with meshtasticd |
+| RSSI looks weak at short range | Check `hops=0 direct` on `>> PKT` line; values are from meshtasticd unchanged. Weak direct RSSI usually means the other radio's antenna/TX, not Meshpoint |
+
+See also [`docs/plans/wisemesh-node-meshtasticd.md`](plans/wisemesh-node-meshtasticd.md) for IPC spike notes and [`docs/plans/WISMESH-BRANCH.md`](plans/WISMESH-BRANCH.md) for full branch architecture.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -137,6 +137,8 @@ The install script handles everything: system packages, SPI/UART/GPS kernel conf
 
 This takes 5-15 minutes depending on your internet speed and Pi model.
 
+> **WisMesh Node (RAK6421 HAT, experimental):** Documented on `main` (see [README Option E](../README.md#option-e-wismesh-node-rak6421-hat-experimental) and [Hardware Matrix](HARDWARE-MATRIX.md#wismesh-node-rak6421-hat-experimental)). Software is on branch **`feat/wismesh-hat`** until v0.7.6: use `sudo bash /opt/meshpoint/scripts/install.sh --platform node` instead of the gateway install above. The Node installer configures **meshtasticd** and installs the bundled **RAK13302 1W** LoRa preset by default (standard for WisBlock slot 1). See [`docs/plans/WISMESH-BRANCH.md`](plans/WISMESH-BRANCH.md).
+
 ### Step 6: Reboot
 
 The SPI and UART kernel changes require a reboot:

--- a/docs/plans/WISMESH-BRANCH.md
+++ b/docs/plans/WISMESH-BRANCH.md
@@ -1,0 +1,189 @@
+# WisMesh Node platform (`feat/wismesh-hat`)
+
+Experimental **Meshpoint Node** support for the RAK6421 WisMesh Pi HAT (meshtasticd-backed RF).
+**Discovery docs** (README Option E, Hardware Matrix, Onboarding, migration guide) are on **`main`** so users can find the HAT before the code ships.
+**Installer and runtime** remain on branch **`feat/wismesh-hat`** until **v0.7.6** merges.
+Gateway users (RAK2287 / SenseCap M1 concentrators) should stay on **`main`** for production installs.
+
+**Last updated:** 2026-05-31 (dashboard meshtasticd control plane + platform UI)
+
+## Dashboard UI (WisMesh Node)
+
+On `device.platform: node`, Configuration and Radio tabs branch on `GET /api/config` (`device.platform`, `capture.meshtasticd`, `meshtasticd_runtime`).
+
+| Area | What operators see |
+|------|-------------------|
+| **Configuration → Identity** | Device name (Meshradar) + live long/short from meshtasticd; Save pushes `PUT /api/meshtasticd/identity`. Node ID read-only (HAT MAC). |
+| **Configuration → Transmit** | **WisBlock module** picker (RAK13300 vs RAK13302 1W) → `PUT /api/meshtasticd/module-preset` (installs yaml, restarts meshtasticd). **Meshtastic radio** card: TX enable, power, region, modem preset → `PUT /api/meshtasticd/radio`. No native SX1302 relay controls. |
+| **Configuration → Radio** | WisMesh status hero (bridge pill, RAK13300/13302 badge, node id). NodeInfo cadence + Send Now (setOwner via bridge). No concentrator SF/BW editor. |
+| **Configuration → MeshCore** | Full USB companion form + dual-radio callout (explicit `meshcore_usb` in sources; autostart suppressed on node). |
+| **Radio tab** | Observational meshtasticd readouts; duty gauge hidden; NodeInfo countdown kept. |
+| **Settings → Dangerous** | No **Restart concentrator**; **Force NodeInfo** calls meshtasticd `setOwner`. |
+
+**meshtasticd docs:** [Usage](https://meshtastic.org/docs/meshtasticd/usage/) (TCP port 4403, single client). Python API: `TCPInterface`, `localNode.setOwner`, `writeConfig("lora")` per [python.meshtastic.org](https://python.meshtastic.org/).
+
+**Marketing hook:** dashboard **WisBlock module** selection lets experimenters swap RAK13300 (standard) and RAK13302 1W (PA) without SSH. After apply, restart Meshpoint once so the TCP bridge reconnects.
+
+| Module | meshtasticd preset | Typical use |
+|--------|-------------------|-------------|
+| RAK13302 1W | `lora-RAK6421-13302-slot1.yaml` | Default. SKY66122 PA, high ERP experiments |
+| RAK13300 | `lora-RAK6421-13300-slot1.yaml` | Standard ~22 dBm WisBlock |
+
+## Architecture
+
+```
+[SX1262 HAT] <--SPI--> meshtasticd (Portduino, owns RF)
+                              |
+                         TCP :4403 (Phone API, single client)
+                              |
+              meshtasticd_bridge_worker (subprocess)
+                              |
+                    meshtastic-python LockedTCPInterface
+                              |
+              MeshtasticdBridgeSource (parent process)
+                              |
+                   decode / store / dashboard / upstream
+```
+
+**Why a worker subprocess:** meshtasticd exposes a **single-client** Phone API with a global read cursor. Running meshtastic-python inside uvicorn caused stream stalls (TCP `Recv-Q` growth, live OTA silence while meshtasticd still forwarded to phone). The worker owns one TCP session for the process lifetime; the parent only reads `RawCapture` objects from a queue and sends TX commands over IPC.
+
+**Key modules:**
+
+| File | Role |
+|------|------|
+| `src/capture/meshtasticd_bridge_worker.py` | Subprocess: TCP connect, pubsub receive, TX commands |
+| `src/capture/meshtasticd_bridge_source.py` | Spawns worker, async packet iterator, TX API |
+| `src/capture/meshtasticd_stream_client.py` | `LockedTCPInterface`: serializes **writes** only (read lock deadlocks connect) |
+| `src/capture/meshtasticd_bridge_ipc.py` | Command/response protocol |
+| `src/capture/meshtastic_packet_adapter.py` | meshtastic-python dict → `RawCapture` / API decode path |
+| `src/api/message_routing.py` | DM identity: meshtasticd node id vs `transmit.node_id` |
+| `src/transmit/meshtasticd_tx_client.py` | TX via bridge commands (not in-process interface) |
+| `scripts/meshpoint-node.service` | `After=meshtasticd.service`, no concentrator reset |
+
+**Node platform rules:**
+
+- **meshtasticd owns RF TX.** Dashboard edits identity and LoRa via `/api/meshtasticd/*` (bridge `setOwner` / `writeConfig("lora")`). Periodic NodeInfo uses `NodeInfoBroadcaster` → `send_nodeinfo` → bridge `setOwner` (interval from `transmit.nodeinfo` in yaml).
+- **Do not run** `meshtastic --host localhost:4403` while Meshpoint is running (steals the single client slot).
+- **Restart order:** `meshtasticd` first, then `meshpoint` (clears stale TCP state).
+
+## Install (6421 + WisBlock module)
+
+```bash
+cd /opt/meshpoint
+sudo git fetch origin
+sudo git checkout feat/wismesh-hat
+sudo git pull origin feat/wismesh-hat
+sudo ./scripts/install.sh --platform node
+sudo meshpoint setup
+sudo systemctl restart meshtasticd meshpoint
+```
+
+`install.sh --platform node` will:
+
+- Skip the SX1302 HAL build
+- Install and configure **meshtasticd** (Debian 12/13 OBS repo)
+- Copy the **RAK13302 1W** LoRa preset (bundled in `config/meshtasticd/`; falls back if meshtasticd package lacks it)
+- Install `meshpoint-node.service` (starts **after** meshtasticd)
+
+The setup wizard writes `device.platform: node` and `capture.sources: [meshtasticd]`.
+
+## Verify
+
+```bash
+systemctl status meshtasticd meshpoint
+ss -tn state established '( sport = :4403 or dport = :4403 )'
+journalctl -u meshpoint -n 50 --no-pager | grep -E 'bridge connected|>> PKT|DM identity'
+```
+
+Healthy signs:
+
+- `meshtasticd bridge connected to 127.0.0.1:4403 (worker pid=...)`
+- `Meshtastic DM identity: ...` listing meshtasticd's live node id
+- TCP `Recv-Q` stays **0** under load
+- OTA `>> PKT` lines continue past 2+ minutes (not just at boot)
+
+Optional CLI probe (stop Meshpoint first):
+
+```bash
+sudo systemctl stop meshpoint
+/opt/meshpoint/venv/bin/meshtastic --host localhost:4403 --info
+sudo systemctl start meshpoint
+```
+
+## Direct messages (phone → Meshpoint)
+
+Meshtastic DMs target **meshtasticd's node id** (derived from the HAT MAC), not necessarily `transmit.node_id` in `local.yaml`.
+
+Meshpoint accepts DMs for **both** ids when they differ. Startup log example:
+
+```
+WARNING server: meshtasticd node id 9ea7e9d9 differs from transmit.node_id 7e3fa19c; routing DMs to meshtasticd identity
+INFO    server: Meshtastic DM identity: 7e3fa19c, 9ea7e9d9
+```
+
+If DMs decode in logs but do not appear on the Messages tab, check that warning was absent before the DM routing fix. Old rows saved as `direction=overheard` are hidden unless `GET /api/messages/conversations?include_overheard=true`.
+
+**Recommendation:** On Node platforms, remove a stale pinned `transmit.node_id` from `local.yaml` unless you intentionally need it for upstream identity. Let meshtasticd own the RF node id.
+
+## Packet log: hops and RSSI
+
+`>> PKT` lines now include hop metadata after SNR:
+
+```
+>> PKT  meshtastic  a0dd8936 -> ffffffff  TEXT  rssi -117.0 ... snr -7.2 hl=7/7 hops=0 relay=0x36 direct  "Yes"
+```
+
+| Field | Meaning |
+|-------|---------|
+| `hl=7/7` | Remaining hops / hop start |
+| `hops=0` | Hops consumed (`hop_start - hop_limit`) |
+| `relay=0x36` | Last relay byte from Meshtastic header |
+| `direct` | Heard directly (0 hops consumed) |
+| `relayed` | At least one relay hop |
+
+**RSSI on Node:** Values come from meshtasticd's SX1262 driver unchanged. Meshpoint does not attenuate them. `--` on `9ea7e9d9` telemetry is normal (locally generated, no OTA RX). Weak RSSI at short range usually indicates the **other node's TX/antenna**, not the WisMesh receiver. Compare direct copies (`hops=0`) only; the wider mesh also delivers relayed copies at -120 dBm that are not shown in `>> PKT`.
+
+## Migrate between platforms
+
+See [`docs/MIGRATE-GATEWAY-TO-NODE.md`](../MIGRATE-GATEWAY-TO-NODE.md) and `meshpoint migrate-platform --to node|gateway`.
+
+## Switch back to Gateway (concentrator)
+
+```bash
+cd /opt/meshpoint
+sudo git checkout main
+sudo git pull origin main
+sudo meshpoint migrate-platform --to gateway --force
+sudo ./scripts/install.sh --platform gateway
+sudo systemctl restart meshpoint
+```
+
+Preserve `config/local.yaml` if you want the same `device_id` and API key.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Logs stop after ~2 min, meshtasticd still RX | Stale TCP / in-process reader | Use current branch (worker bridge); restart `meshtasticd` then `meshpoint` |
+| `bridge connected` never appears | Read-lock deadlock (fixed) or meshtasticd down | `systemctl restart meshtasticd meshpoint`; check port 4403 |
+| DM in logs, not on dashboard | DM routed to wrong node id | Pull latest; check `Meshtastic DM identity` log line |
+| `meshtastic --host` while Meshpoint runs | Second client corrupts stream | Stop Meshpoint before CLI probe |
+| meshtasticd crash: blank MAC | Missing MAC source | `General.MACAddressSource: eth0` in `/etc/meshtasticd/config.yaml` |
+| meshtasticd crash: no preset | Missing HAT preset | Re-run `sudo ./scripts/install_meshtasticd.sh` or copy bundled `config/meshtasticd/lora-RAK6421-13302-slot1.yaml` |
+| TX power stuck at ~22 dBm on RAK13302 | Wrong preset (13300) or PA power jumper | Confirm preset name in `meshtastic --host localhost:4403 --info`; use 13302 yaml + 5V PA jumper |
+| Dashboard Apply fails at `install.sh` | Interrupted dpkg or git synced but install did not finish | `sudo dpkg --configure -a`, then Apply again. Current branch heals dpkg and skips dist-upgrade on upgrade |
+
+## Tests
+
+From repo root:
+
+```bash
+python -m pytest tests/test_meshtasticd_bridge.py tests/test_meshtasticd_bridge_ipc.py \
+  tests/test_meshtasticd_stream_client.py tests/test_meshtasticd_daemon.py \
+  tests/test_message_routing.py tests/test_log_format_rssi.py -q
+```
+
+## Related docs
+
+- [`wisemesh-node-meshtasticd.md`](wisemesh-node-meshtasticd.md): meshtasticd IPC spike notes
+- [`MIGRATE-GATEWAY-TO-NODE.md`](../MIGRATE-GATEWAY-TO-NODE.md): migration runbook

--- a/docs/plans/wisemesh-node-meshtasticd.md
+++ b/docs/plans/wisemesh-node-meshtasticd.md
@@ -1,0 +1,122 @@
+# WisMesh Node: meshtasticd IPC spike
+
+**Host:** `192.168.0.194` (`meshpoint-1`)  
+**OS:** Debian 13 (trixie)  
+**HAT:** RAK6421 (`6421 Pi Hat`, vendor `RAK`)  
+**meshtasticd:** 2.7.15  
+**Branch:** `feat/wismesh-hat`  
+**Date:** 2026-05-22
+
+## Install (Debian 13)
+
+Pi OS on this unit reports **Debian 13 (trixie)**. Use the **Debian_13** OBS repo:
+
+```bash
+echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Debian_13/ /' | sudo tee /etc/apt/sources.list.d/network:Meshtastic:beta.list
+curl -fsSL https://download.opensuse.org/repositories/network:Meshtastic:beta/Debian_13/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/network_Meshtastic_beta.gpg > /dev/null
+sudo apt update
+sudo apt install meshtasticd
+```
+
+### RAK6421 LoRa preset
+
+`scripts/install_meshtasticd.sh` (via `install.sh --platform node`) installs the **RAK13302 1W** preset by default:
+
+- Bundled at `config/meshtasticd/lora-RAK6421-13302-slot1.yaml` (meshtasticd 2.7.x packages often ship only the 13300 preset in `available.d/`)
+- Copied to `/etc/meshtasticd/config.d/` with `Enable_Pins`, `TX_GAIN_LORA`, and `CS: 8` for the Pi SPI overlay
+
+**RAK13300 (standard power):** set `meshtasticd.preset: lora-RAK6421-13300-slot1.yaml` in `local.yaml` and re-run `sudo ./scripts/install_meshtasticd.sh`, or `MESHTASTICD_PRESET=lora-RAK6421-13300-slot1.yaml sudo ./scripts/install.sh --platform node`.
+
+**13302 hardware power:** the RAK13302 module has a 3-pin jumper for the 5V PA rail. External 5V or battery power may be required for full 1W output; software preset alone does not enable the PA if power is wrong.
+
+Manual copy (only if not using Meshpoint installer):
+
+```bash
+sudo mkdir -p /etc/meshtasticd/config.d
+sudo cp /opt/meshpoint/config/meshtasticd/lora-RAK6421-13302-slot1.yaml /etc/meshtasticd/config.d/
+```
+
+### MAC address (required on fresh install)
+
+meshtasticd **will not start** without a node MAC. Put this in `/etc/meshtasticd/config.yaml`:
+
+```yaml
+General:
+  MACAddressSource: eth0
+```
+
+Use `wlan0` if Ethernet is down. meshtasticd derives the Meshtastic node ID from this MAC.
+
+```bash
+sudo systemctl enable --now meshtasticd
+```
+
+**Failure modes seen on spike:**
+
+| Log line | Fix |
+|----------|-----|
+| `Unable to find config for 6421 Pi Hat` | Re-run `sudo ./scripts/install_meshtasticd.sh` or copy bundled preset from `config/meshtasticd/` |
+| `Blank MAC Address not allowed` | Add `General.MACAddressSource` to `config.yaml` |
+
+## IPC: Meshtastic Python CLI → TCP `4403`
+
+meshtasticd listens on **`0.0.0.0:4403`**. Use the **Meshpoint venv** CLI (already in `requirements.txt`):
+
+```bash
+/opt/meshpoint/venv/bin/meshtastic --host localhost:4403 --info
+/opt/meshpoint/venv/bin/meshtastic --host localhost:4403 --export-config
+```
+
+There is no `/usr/bin/meshtastic` system binary on this Pi; only `/usr/bin/meshtasticd`.
+
+### `--info` snapshot (2026-05-22)
+
+```
+Connected to radio
+Metadata: hwModel=PORTDUINO, firmwareVersion=2.7.15, role=CLIENT
+Preferences.lora: txPower=30, modemPreset=LONG_FAST, txEnabled=true, region=UNSET
+Active preset file: lora-RAK6421-13302-slot1.yaml
+```
+
+### Fields for Meshpoint display (High power badge)
+
+| Signal | Source | Spike result |
+|--------|--------|--------------|
+| Module SKU | Preset filename in `/etc/meshtasticd/config.d/` | `lora-RAK6421-13302-slot1.yaml` (default; bundled in Meshpoint repo) |
+| TX power | `Preferences.lora.txPower` from `--info` | **30** dBm reported |
+| `hw_model` | `Metadata.hwModel` | **PORTDUINO** (does not distinguish RAK13300 vs RAK13302) |
+
+No dedicated `high_power` API field. Badge logic: `13302` in preset name and/or `txPower > 20` as display-only hints.
+
+## Meshpoint Phase 0 validation (same Pi)
+
+With `feat/wismesh-hat` checked out:
+
+```
+Platform:        Node (meshtasticd)
+Concentrator:    SPI present but no SX1302/SX1303 response
+WisMesh HAT:     RAK6421 detected
+```
+
+libloragw installed from prior Gateway experiments does **not** trigger false Gateway when chip probe returns none.
+
+## Phase 2 bridge (shipped 2026-05-31)
+
+Production bridge on `feat/wismesh-hat`. See [WISMESH-BRANCH.md](./WISMESH-BRANCH.md) for install and troubleshooting.
+
+| Concern | Implementation |
+|---------|----------------|
+| **Capture** | `meshtasticd_bridge_worker` subprocess owns one `TCPInterface` on `:4403`; parent reads `RawCapture` from a queue |
+| **Why subprocess** | meshtasticd Phone API is single-client; in-process TCP inside uvicorn caused Recv-Q stalls and live OTA silence |
+| **TX** | `MeshtasticdTxClient` sends commands to worker over IPC (no second TCP client) |
+| **Stream safety** | `LockedTCPInterface` serializes writes only; read-lock caused connect deadlock |
+| **NodeInfo** | Skipped on `device.platform: node` (meshtasticd owns identity) |
+| **DM routing** | Accept DMs for meshtasticd live node id and optional `transmit.node_id` (`message_routing.py`) |
+| **systemd** | `meshpoint-node.service` `After=meshtasticd.service` |
+| **Stall recovery** | Worker reconnects TCP after 90s with no packets; reader thread watchdog |
+
+**Spike lesson retained:** never run `meshtastic --host localhost:4403` while Meshpoint is running.
+
+## Pi checkout
+
+See [WISMESH-BRANCH.md](./WISMESH-BRANCH.md).


### PR DESCRIPTION
## Summary
- Publish WisMesh Node documentation on main before v0.7.6 merges the runtime.
- README Option E, Hardware Matrix, Onboarding, MIGRATE-GATEWAY-TO-NODE, WISMESH-BRANCH plan.
- States installer stays on feat/wismesh-hat until v0.7.6.

## Not included
- No code or config/meshtasticd presets (feature branch only).

## Test plan
- [ ] README and Hardware Matrix links render on GitHub
- [ ] Docs-only merge to main