### PR TITLE
feat(rf): RF Environment tab exposing spectral scan + noise floor

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -490,6 +490,14 @@ dashboard:
 
 Access at `http://<pi-ip>:8080`. Bind to `127.0.0.1` to restrict to local access only.
 
+### RF Environment tab
+
+Open **RF Environment** in the sidebar for a full-page noise-floor sparkline, calibration state, and the latest SX1302 spectral-scan histogram. Data comes from `GET /api/rf/status` (same sources as the sidebar telemetry rail).
+
+- **Live scan** — hardware spectral scan on the tuned channel (`radio.spectral_scan_interval_seconds` > 0 and SX1261/HAL support present)
+- **Packet fallback** — rolling minimum of `RSSI − SNR` when scan is disabled or unavailable
+- Set `radio.spectral_scan_interval_seconds: 0` in **Configuration → Advanced** to disable hardware scan; the tab shows a clear message and uses packet fallback only
+
 ---
 
 ## Device Identity

--- a/frontend/css/rf.css
+++ b/frontend/css/rf.css
@@ -92,26 +92,26 @@
 }
 
 .rf-badge--live {
-    background: rgba(34, 197, 94, 0.15);
-    color: #4ade80;
-    border: 1px solid rgba(34, 197, 94, 0.35);
+    background: rgba(0, 229, 160, 0.15);
+    color: var(--accent-green);
+    border: 1px solid rgba(0, 229, 160, 0.35);
 }
 
 .rf-badge--fallback {
     background: rgba(245, 158, 11, 0.12);
-    color: #fbbf24;
+    color: var(--accent-amber);
     border: 1px solid rgba(245, 158, 11, 0.35);
 }
 
 .rf-badge--calibrating {
     background: rgba(100, 116, 139, 0.2);
-    color: #cbd5e1;
+    color: var(--text-secondary);
     border: 1px solid rgba(100, 116, 139, 0.4);
 }
 
 .rf-badge--off {
     background: rgba(71, 85, 105, 0.25);
-    color: #94a3b8;
+    color: var(--text-secondary);
     border: 1px solid rgba(71, 85, 105, 0.5);
 }
 

--- a/frontend/css/rf.css
+++ b/frontend/css/rf.css
@@ -1,0 +1,171 @@
+.section[data-section="rf"] {
+    overflow-y: auto;
+}
+
+.rf-panel {
+    padding: 1.25rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.rf-panel__header {
+    margin-bottom: 1rem;
+}
+
+.rf-panel__title {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text-primary, #f1f5f9);
+}
+
+.rf-panel__desc {
+    margin: 0.35rem 0 0;
+    font-size: 0.78rem;
+    color: var(--text-secondary, #94a3b8);
+    max-width: 40rem;
+}
+
+.rf-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+@media (min-width: 768px) {
+    .rf-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+    .rf-card--wide {
+        grid-column: 1 / -1;
+    }
+}
+
+.rf-card {
+    background: var(--bg-card, rgba(15, 23, 42, 0.65));
+    border: 1px solid var(--border, rgba(51, 65, 85, 0.8));
+    border-radius: var(--radius, 8px);
+    padding: 1rem;
+}
+
+.rf-card__title {
+    margin: 0 0 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary, #e2e8f0);
+}
+
+.rf-card__hint {
+    margin: 0 0 0.75rem;
+    font-size: 0.72rem;
+    color: var(--text-secondary, #94a3b8);
+}
+
+.rf-readout {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.rf-readout__value {
+    font-size: 1.6rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary, #f8fafc);
+}
+
+.rf-readout__unit {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94a3b8);
+}
+
+.rf-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.rf-badge--live {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+    border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.rf-badge--fallback {
+    background: rgba(245, 158, 11, 0.12);
+    color: #fbbf24;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.rf-badge--calibrating {
+    background: rgba(100, 116, 139, 0.2);
+    color: #cbd5e1;
+    border: 1px solid rgba(100, 116, 139, 0.4);
+}
+
+.rf-badge--off {
+    background: rgba(71, 85, 105, 0.25);
+    color: #94a3b8;
+    border: 1px solid rgba(71, 85, 105, 0.5);
+}
+
+.rf-sparkline-wrap {
+    height: 72px;
+    margin-top: 0.25rem;
+}
+
+.rf-sparkline-wrap canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.rf-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+    color: var(--text-secondary, #94a3b8);
+}
+
+.rf-meta dt {
+    margin: 0;
+    font-weight: 500;
+    color: var(--text-muted, #64748b);
+}
+
+.rf-meta dd {
+    margin: 0.1rem 0 0;
+    color: var(--text-primary, #e2e8f0);
+}
+
+.rf-histogram-wrap {
+    position: relative;
+    min-height: 220px;
+}
+
+.rf-histogram-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 180px;
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94a3b8);
+    text-align: center;
+    padding: 1rem;
+}
+
+.rf-scan-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    margin-top: 0.75rem;
+    font-size: 0.72rem;
+    color: var(--text-secondary, #94a3b8);
+}

--- a/frontend/css/status_strip.css
+++ b/frontend/css/status_strip.css
@@ -1,0 +1,105 @@
+/* Operator status footer — console-style telemetry in panel chrome. */
+
+.status-strip {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 1.25rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    background: rgba(6, 182, 212, 0.03);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+
+.status-strip__label {
+    color: var(--text-secondary);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    font-size: 0.62rem;
+}
+
+.status-strip__sep {
+    opacity: 0.35;
+}
+
+.status-strip__items {
+    color: var(--accent-cyan);
+    text-shadow: 0 0 6px rgba(6, 182, 212, 0.12);
+}
+
+.status-strip__updated {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.status-strip--quiet .status-strip__items {
+    color: var(--text-muted);
+    text-shadow: none;
+    font-style: italic;
+}
+
+.map-topology-hint {
+    position: absolute;
+    left: 50%;
+    bottom: 2.75rem;
+    transform: translateX(-50%);
+    z-index: 800;
+    max-width: min(92%, 28rem);
+    padding: 0.45rem 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    background: rgba(15, 23, 42, 0.92);
+    color: var(--accent-amber);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.03em;
+    text-align: center;
+    pointer-events: none;
+    box-shadow: var(--glow-amber);
+}
+
+.mqtt-runtime {
+    margin: 0 0 1rem;
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(0, 229, 160, 0.04);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.03em;
+    color: var(--text-muted);
+}
+
+.mqtt-runtime--offline {
+    background: rgba(239, 68, 68, 0.06);
+    border-color: rgba(239, 68, 68, 0.25);
+}
+
+.mqtt-runtime--disabled {
+    background: rgba(100, 116, 139, 0.08);
+}
+
+.mqtt-runtime__label {
+    color: var(--text-secondary);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    font-size: 0.62rem;
+    margin-right: 0.35rem;
+}
+
+.mqtt-runtime__state {
+    color: var(--accent-green);
+}
+
+.mqtt-runtime--offline .mqtt-runtime__state {
+    color: var(--accent-red);
+}
+
+.mqtt-runtime--disabled .mqtt-runtime__state {
+    color: var(--text-muted);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/dashboard.css" />
+    <link rel="stylesheet" href="css/rf.css" />
     <link rel="stylesheet" href="sidebar/sidebar.css" />
     <link rel="stylesheet" href="topbar/topbar.css" />
     <link rel="stylesheet" href="css/build_stamp.css" />
@@ -100,6 +101,20 @@
                                 </svg>
                             </span>
                             <span class="sidebar__label">Stats</span>
+                        </a>
+                    </li>
+                    <li class="sidebar__item">
+                        <a href="#/rf" class="sidebar__link" data-route="rf">
+                            <span class="sidebar__icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <path d="M4 18v-4"/>
+                                    <path d="M8 18V8"/>
+                                    <path d="M12 18v-6"/>
+                                    <path d="M16 18V4"/>
+                                    <path d="M20 18v-9"/>
+                                </svg>
+                            </span>
+                            <span class="sidebar__label">RF Environment</span>
                         </a>
                     </li>
                     <li class="sidebar__item">
@@ -388,6 +403,12 @@
             <section class="section" data-section="stats" style="display:none">
                 <div id="stats-panel" class="stats-panel">
                     <div class="stats-panel__loading">Loading stats...</div>
+                </div>
+            </section>
+
+            <section class="section" data-section="rf" style="display:none">
+                <div id="rf-panel" class="rf-panel">
+                    <div class="stats-panel__loading">Loading RF environment...</div>
                 </div>
             </section>
 
@@ -693,6 +714,7 @@
     <script src="js/radio_companion_card.js"></script>
     <script src="js/radio_settings.js"></script>
     <script src="js/stats_tab.js"></script>
+    <script src="js/rf_tab.js"></script>
     <script src="js/signout_controller.js"></script>
     <script src="js/settings/password_change_form.js"></script>
     <script src="js/settings/sign_out_all_form.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="css/init_checklist.css" />
     <link rel="stylesheet" href="css/route_motion.css" />
     <link rel="stylesheet" href="css/since_line.css" />
+    <link rel="stylesheet" href="css/status_strip.css" />
     <link rel="stylesheet" href="css/command_palette.css" />
     <link rel="stylesheet" href="css/keymap_overlay.css" />
     <link rel="stylesheet" href="css/theme_high_contrast.css" />
@@ -769,6 +770,7 @@
     <script src="topbar/topbar_controller.js"></script>
     <script src="js/build_stamp.js"></script>
     <script src="js/last_visit_tracker.js"></script>
+    <script src="js/status_strip.js"></script>
     <script src="js/since_line.js"></script>
     <script src="js/since_line_controller.js"></script>
     <script src="js/init_checklist.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const router = new Router({
         defaultRoute: 'dashboard',
         allowedRoutes: [
-            'dashboard', 'stats', 'messages', 'radio', 'terminal',
+            'dashboard', 'stats', 'rf', 'messages', 'radio', 'terminal',
             'configuration/identity', 'configuration/radio',
             'configuration/channels', 'configuration/transmit',
             'configuration/mqtt',

--- a/frontend/js/rf_tab.js
+++ b/frontend/js/rf_tab.js
@@ -221,6 +221,10 @@ class RfTab {
         const counts = hist.counts || [];
 
         if (!this._histogramChart) {
+            const root = getComputedStyle(document.documentElement);
+            const token = (name, fallback) => root.getPropertyValue(name).trim() || fallback;
+            const textSecondary = token('--text-secondary', '#94a3b8');
+            const textMuted = token('--text-muted', '#64748b');
             this._histogramChart = new Chart(canvas, {
                 type: 'bar',
                 data: {
@@ -241,19 +245,19 @@ class RfTab {
                         title: {
                             display: true,
                             text: `Floor ${hist.floor_dbm ?? '--'} dBm · Median ${hist.median_dbm ?? '--'} dBm`,
-                            color: '#94a3b8',
+                            color: textSecondary,
                             font: { size: 11 },
                         },
                     },
                     scales: {
                         x: {
-                            title: { display: true, text: 'RSSI level (dBm)', color: '#64748b' },
-                            ticks: { color: '#94a3b8', maxTicksLimit: 12 },
+                            title: { display: true, text: 'RSSI level (dBm)', color: textMuted },
+                            ticks: { color: textSecondary, maxTicksLimit: 12 },
                             grid: { color: 'rgba(51, 65, 85, 0.35)' },
                         },
                         y: {
-                            title: { display: true, text: 'Sample count', color: '#64748b' },
-                            ticks: { color: '#94a3b8' },
+                            title: { display: true, text: 'Sample count', color: textMuted },
+                            ticks: { color: textSecondary },
                             grid: { color: 'rgba(51, 65, 85, 0.35)' },
                             beginAtZero: true,
                         },

--- a/frontend/js/rf_tab.js
+++ b/frontend/js/rf_tab.js
@@ -1,0 +1,289 @@
+/**
+ * RF Environment tab — noise-floor sparkline + spectral histogram.
+ * Reads GET /api/rf/status; live sparkline also accepts WS noise_floor.
+ */
+class RfTab {
+    constructor(containerId) {
+        this._container = document.getElementById(containerId);
+        this._rendered = false;
+        this._refreshInterval = null;
+        this._histogramChart = null;
+        this._sparkline = null;
+        this._wsBound = false;
+    }
+
+    async refresh() {
+        if (!this._container) return;
+
+        try {
+            const res = await fetch('/api/rf/status');
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            if (!this._rendered) {
+                this._buildLayout();
+                this._rendered = true;
+                this._bindWebSocket();
+            }
+            this._update(data);
+        } catch (e) {
+            console.error('RF status refresh failed:', e);
+        }
+
+        if (!this._refreshInterval) {
+            this._refreshInterval = setInterval(() => {
+                const section = document.querySelector('[data-section="rf"]');
+                if (section && section.classList.contains('section--active')) {
+                    this.refresh();
+                } else {
+                    clearInterval(this._refreshInterval);
+                    this._refreshInterval = null;
+                }
+            }, 5000);
+        }
+    }
+
+    _buildLayout() {
+        this._container.innerHTML = `
+            <div class="rf-panel">
+                <header class="rf-panel__header">
+                    <h2 class="rf-panel__title">RF Environment</h2>
+                    <p class="rf-panel__desc">
+                        Local noise-floor readout and the latest SX1302 spectral-scan histogram.
+                        Values marked <span class="rf-badge rf-badge--live">Live scan</span> come from hardware;
+                        <span class="rf-badge rf-badge--fallback">Packet fallback</span> is an upper bound from decoded packets.
+                    </p>
+                </header>
+                <div class="rf-grid">
+                    <article class="rf-card">
+                        <h3 class="rf-card__title">Noise floor</h3>
+                        <p class="rf-card__hint" id="rf-noise-hint">Loading…</p>
+                        <div class="rf-readout">
+                            <span class="rf-readout__value" id="rf-noise-value">--</span>
+                            <span class="rf-readout__unit">dBm</span>
+                            <span id="rf-noise-badge" class="rf-badge rf-badge--calibrating">…</span>
+                        </div>
+                        <div class="rf-sparkline-wrap">
+                            <canvas id="rf-noise-sparkline" aria-label="Noise floor history"></canvas>
+                        </div>
+                        <dl class="rf-meta" id="rf-noise-meta"></dl>
+                    </article>
+                    <article class="rf-card">
+                        <h3 class="rf-card__title">Spectral scan</h3>
+                        <p class="rf-card__hint" id="rf-scan-hint">Loading…</p>
+                        <dl class="rf-meta" id="rf-scan-meta"></dl>
+                        <div class="rf-scan-stats" id="rf-scan-stats"></div>
+                    </article>
+                    <article class="rf-card rf-card--wide">
+                        <h3 class="rf-card__title">Channel histogram</h3>
+                        <p class="rf-card__hint">Latest hardware scan — RSSI level distribution across the tuned channel.</p>
+                        <div class="rf-histogram-wrap">
+                            <canvas id="rf-histogram" aria-label="Spectral scan histogram"></canvas>
+                            <div id="rf-histogram-empty" class="rf-histogram-empty" hidden>
+                                No hardware scan yet. Enable spectral scan under Configuration → Advanced
+                                or wait for the first scheduled scan.
+                            </div>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        `;
+
+        const canvas = document.getElementById('rf-noise-sparkline');
+        if (canvas && window.NoiseFloorSparkline) {
+            this._sparkline = new window.NoiseFloorSparkline(canvas);
+        }
+    }
+
+    _bindWebSocket() {
+        if (this._wsBound || !window.concentratorWS) return;
+        this._wsBound = true;
+        window.concentratorWS.on('noise_floor', (frame) => {
+            const section = document.querySelector('[data-section="rf"]');
+            if (!section || !section.classList.contains('section--active')) return;
+            this._updateNoiseFloor(frame);
+        });
+    }
+
+    _update(data) {
+        this._updateNoiseFloor(data.noise_floor || {});
+        this._updateSpectralScan(data.spectral_scan || {});
+    }
+
+    _updateNoiseFloor(nf) {
+        const valueEl = document.getElementById('rf-noise-value');
+        const badgeEl = document.getElementById('rf-noise-badge');
+        const hintEl = document.getElementById('rf-noise-hint');
+        const metaEl = document.getElementById('rf-noise-meta');
+        if (!valueEl || !badgeEl) return;
+
+        const source = nf.source || 'packets';
+        const calibrating = !!nf.calibrating;
+        const stale = !!nf.stale;
+        const value = nf.value_dbm;
+
+        if (calibrating || value == null) {
+            valueEl.textContent = '--';
+        } else {
+            valueEl.textContent = Number(value).toFixed(1);
+        }
+
+        badgeEl.className = 'rf-badge';
+        if (calibrating) {
+            badgeEl.classList.add('rf-badge--calibrating');
+            badgeEl.textContent = 'Calibrating';
+        } else if (source === 'spectral_scan') {
+            badgeEl.classList.add('rf-badge--live');
+            badgeEl.textContent = stale ? 'Live scan (stale)' : 'Live scan';
+        } else {
+            badgeEl.classList.add('rf-badge--fallback');
+            badgeEl.textContent = stale ? 'Packet fallback (stale)' : 'Packet fallback';
+        }
+
+        if (hintEl) {
+            hintEl.textContent = RfTab._noiseHint(nf);
+        }
+
+        if (metaEl) {
+            const bw = nf.bandwidth_khz != null ? `${nf.bandwidth_khz} kHz` : '--';
+            const theory = nf.theoretical_floor_dbm != null
+                ? `${Number(nf.theoretical_floor_dbm).toFixed(1)} dBm` : '--';
+            const median = nf.median_dbm != null
+                ? `${Number(nf.median_dbm).toFixed(1)} dBm` : '--';
+            metaEl.innerHTML = `
+                <div><dt>Bandwidth</dt><dd>${bw}</dd></div>
+                <div><dt>Theoretical floor</dt><dd>${theory}</dd></div>
+                <div><dt>Median (scan)</dt><dd>${median}</dd></div>
+                <div><dt>Samples</dt><dd>${nf.samples_count ?? 0}</dd></div>
+            `;
+        }
+
+        if (this._sparkline) {
+            this._sparkline.setSamples(
+                nf.samples_dbm || [],
+                nf.theoretical_floor_dbm,
+            );
+        }
+    }
+
+    _updateSpectralScan(scan) {
+        const hintEl = document.getElementById('rf-scan-hint');
+        const metaEl = document.getElementById('rf-scan-meta');
+        const statsEl = document.getElementById('rf-scan-stats');
+        const emptyEl = document.getElementById('rf-histogram-empty');
+        const canvas = document.getElementById('rf-histogram');
+
+        if (hintEl) {
+            hintEl.textContent = scan.message || (
+                scan.running
+                    ? `Scanning every ${scan.interval_seconds || 0}s on the active channel.`
+                    : 'Spectral scan service is not running.'
+            );
+        }
+
+        if (metaEl) {
+            const freq = scan.frequency_hz != null
+                ? `${(scan.frequency_hz / 1e6).toFixed(3)} MHz` : '--';
+            const enabled = scan.enabled ? 'Yes' : 'No';
+            const supported = scan.supported ? 'Yes' : 'No';
+            const running = scan.running ? 'Yes' : 'No';
+            metaEl.innerHTML = `
+                <div><dt>Enabled</dt><dd>${enabled}</dd></div>
+                <div><dt>Hardware</dt><dd>${supported}</dd></div>
+                <div><dt>Running</dt><dd>${running}</dd></div>
+                <div><dt>Frequency</dt><dd>${freq}</dd></div>
+                <div><dt>Interval</dt><dd>${scan.interval_seconds ?? 0}s</dd></div>
+            `;
+        }
+
+        if (statsEl) {
+            statsEl.innerHTML = `
+                <span>Scans completed: <strong>${scan.scans_run ?? 0}</strong></span>
+                <span>Failed: <strong>${scan.scans_failed ?? 0}</strong></span>
+            `;
+        }
+
+        const hist = scan.histogram;
+        const hasHist = hist && Array.isArray(hist.levels_dbm) && hist.levels_dbm.length > 0
+            && (hist.total_samples > 0 || (hist.counts || []).some((c) => c > 0));
+
+        if (emptyEl) emptyEl.hidden = !!hasHist;
+        if (canvas) canvas.hidden = !hasHist;
+
+        if (!hasHist || typeof Chart === 'undefined') {
+            if (this._histogramChart) {
+                this._histogramChart.destroy();
+                this._histogramChart = null;
+            }
+            return;
+        }
+
+        const labels = hist.levels_dbm.map((lvl) => `${lvl}`);
+        const counts = hist.counts || [];
+
+        if (!this._histogramChart) {
+            this._histogramChart = new Chart(canvas, {
+                type: 'bar',
+                data: {
+                    labels,
+                    datasets: [{
+                        label: 'Samples',
+                        data: counts,
+                        backgroundColor: 'rgba(6, 182, 212, 0.55)',
+                        borderColor: 'rgba(6, 182, 212, 0.9)',
+                        borderWidth: 1,
+                    }],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        title: {
+                            display: true,
+                            text: `Floor ${hist.floor_dbm ?? '--'} dBm · Median ${hist.median_dbm ?? '--'} dBm`,
+                            color: '#94a3b8',
+                            font: { size: 11 },
+                        },
+                    },
+                    scales: {
+                        x: {
+                            title: { display: true, text: 'RSSI level (dBm)', color: '#64748b' },
+                            ticks: { color: '#94a3b8', maxTicksLimit: 12 },
+                            grid: { color: 'rgba(51, 65, 85, 0.35)' },
+                        },
+                        y: {
+                            title: { display: true, text: 'Sample count', color: '#64748b' },
+                            ticks: { color: '#94a3b8' },
+                            grid: { color: 'rgba(51, 65, 85, 0.35)' },
+                            beginAtZero: true,
+                        },
+                    },
+                },
+            });
+            return;
+        }
+
+        this._histogramChart.data.labels = labels;
+        this._histogramChart.data.datasets[0].data = counts;
+        if (this._histogramChart.options.plugins.title) {
+            this._histogramChart.options.plugins.title.text =
+                `Floor ${hist.floor_dbm ?? '--'} dBm · Median ${hist.median_dbm ?? '--'} dBm`;
+        }
+        this._histogramChart.update('none');
+    }
+
+    static _noiseHint(nf) {
+        if (nf.calibrating) {
+            return 'Waiting for the first spectral scan or a few packets before reporting a number.';
+        }
+        if (nf.value_dbm == null) {
+            return 'No noise floor data yet.';
+        }
+        if (nf.source === 'spectral_scan') {
+            return 'Direct ambient channel power from the SX1302 spectral scan on the tuned frequency.';
+        }
+        return 'Upper bound from rolling minimum of (RSSI − SNR) on decoded packets. True floor is at or below this value.';
+    }
+}
+
+window.rfTab = new RfTab('rf-panel');

--- a/frontend/js/rf_tab.js
+++ b/frontend/js/rf_tab.js
@@ -10,6 +10,8 @@ class RfTab {
         this._histogramChart = null;
         this._sparkline = null;
         this._wsBound = false;
+        this._statusStrip = null;
+        this._fetchedAt = null;
     }
 
     async refresh() {
@@ -19,6 +21,7 @@ class RfTab {
             const res = await fetch('/api/rf/status');
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
+            this._fetchedAt = Date.now();
             if (!this._rendered) {
                 this._buildLayout();
                 this._rendered = true;
@@ -85,8 +88,15 @@ class RfTab {
                         </div>
                     </article>
                 </div>
+                <div id="rf-status-strip-host"></div>
             </div>
         `;
+
+        const stripHost = document.getElementById('rf-status-strip-host');
+        if (stripHost && window.StatusStrip) {
+            this._statusStrip = new window.StatusStrip(stripHost, 'RF ENV');
+            this._statusStrip.mount();
+        }
 
         const canvas = document.getElementById('rf-noise-sparkline');
         if (canvas && window.NoiseFloorSparkline) {
@@ -107,6 +117,20 @@ class RfTab {
     _update(data) {
         this._updateNoiseFloor(data.noise_floor || {});
         this._updateSpectralScan(data.spectral_scan || {});
+        this._updateStatusStrip(data.noise_floor || {}, data.spectral_scan || {});
+    }
+
+    _updateStatusStrip(nf, scan) {
+        if (!this._statusStrip) return;
+        const source = nf.source === 'spectral_scan' ? 'live scan' : 'packet fallback';
+        const noise = nf.value_dbm != null ? `${Number(nf.value_dbm).toFixed(1)} dBm` : 'calibrating';
+        const samples = nf.samples_count ?? 0;
+        const scanState = scan.running ? 'scan on' : 'scan off';
+        const scans = scan.scans_run != null ? `${scan.scans_run} scans` : 'no scans';
+        this._statusStrip.update(
+            [noise, source, `${samples} samples`, scanState, scans],
+            this._fetchedAt,
+        );
     }
 
     _updateNoiseFloor(nf) {

--- a/frontend/js/status_strip.js
+++ b/frontend/js/status_strip.js
@@ -1,0 +1,65 @@
+/**
+ * Console-style operator status footer for analytics tabs.
+ *
+ * Renders a slim monospace strip at the bottom of a panel:
+ *   TRAFFIC · concentrator · 8,247 pkts · updated 14s ago
+ */
+class StatusStrip {
+    constructor(hostEl, label) {
+        this._host = hostEl;
+        this._label = (label || 'STATUS').toUpperCase();
+        this._root = null;
+        this._itemsEl = null;
+        this._updatedEl = null;
+    }
+
+    mount() {
+        if (!this._host || this._root) return;
+        const root = document.createElement('footer');
+        root.className = 'status-strip';
+        root.setAttribute('role', 'status');
+        root.setAttribute('aria-live', 'polite');
+        root.innerHTML = `
+            <span class="status-strip__label">${this._label}</span>
+            <span class="status-strip__sep" aria-hidden="true">·</span>
+            <span class="status-strip__items"></span>
+            <span class="status-strip__updated"></span>
+        `;
+        this._host.appendChild(root);
+        this._root = root;
+        this._itemsEl = root.querySelector('.status-strip__items');
+        this._updatedEl = root.querySelector('.status-strip__updated');
+    }
+
+    /**
+     * @param {string[]} items - dot-separated status fragments
+     * @param {Date|number|null} updatedAt - when underlying data was fetched
+     */
+    update(items, updatedAt) {
+        if (!this._root) return;
+        const parts = (items || []).filter((item) => item != null && String(item).trim());
+        this._itemsEl.textContent = parts.length ? parts.join(' · ') : 'waiting for data';
+        this._root.classList.toggle('status-strip--quiet', parts.length === 0);
+
+        if (this._updatedEl) {
+            if (updatedAt) {
+                this._updatedEl.textContent = ` · updated ${_formatRelative(updatedAt)}`;
+            } else {
+                this._updatedEl.textContent = '';
+            }
+        }
+    }
+}
+
+function _formatRelative(timestamp) {
+    const ms = timestamp instanceof Date ? timestamp.getTime() : Number(timestamp);
+    if (!ms) return 'just now';
+    const seconds = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+    if (seconds < 30) return 'just now';
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+window.StatusStrip = StatusStrip;

--- a/frontend/sidebar/sidebar_controller.js
+++ b/frontend/sidebar/sidebar_controller.js
@@ -183,6 +183,9 @@ class SidebarController {
         if (root === 'stats' && window.statsTab) {
             window.statsTab.refresh();
         }
+        if (root === 'rf' && window.rfTab) {
+            window.rfTab.refresh();
+        }
         if (route === 'terminal' && window.terminalController) {
             window.terminalController.onActivated();
         }

--- a/src/api/routes/rf_routes.py
+++ b/src/api/routes/rf_routes.py
@@ -1,0 +1,102 @@
+"""RF Environment dashboard — noise floor + spectral scan exposure."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter
+
+from src.api.telemetry.noise_floor import NoiseFloorTracker
+from src.config import AppConfig
+
+if TYPE_CHECKING:
+    from src.api.telemetry.spectral_scan_service import SpectralScanService
+
+router = APIRouter(prefix="/api/rf", tags=["rf"])
+
+_tracker: NoiseFloorTracker | None = None
+_scan_service: SpectralScanService | None = None
+_config: AppConfig | None = None
+
+
+def init_routes(
+    tracker: NoiseFloorTracker,
+    scan_service: SpectralScanService | None,
+    config: AppConfig,
+) -> None:
+    global _tracker, _scan_service, _config
+    _tracker = tracker
+    _scan_service = scan_service
+    _config = config
+
+
+def _spectral_status() -> dict:
+    radio = _config.radio if _config else None
+    interval = (
+        float(radio.spectral_scan_interval_seconds)
+        if radio and radio.spectral_scan_interval_seconds is not None
+        else 0.0
+    )
+    enabled = interval > 0
+    frequency_hz = (
+        int(radio.frequency_mhz * 1_000_000)
+        if radio and radio.frequency_mhz is not None
+        else None
+    )
+    bandwidth_khz = radio.bandwidth_khz if radio else None
+
+    if not enabled:
+        return {
+            "enabled": False,
+            "supported": False,
+            "running": False,
+            "interval_seconds": interval,
+            "frequency_hz": frequency_hz,
+            "bandwidth_khz": bandwidth_khz,
+            "scans_run": 0,
+            "scans_failed": 0,
+            "histogram": None,
+            "message": (
+                "Hardware spectral scan disabled "
+                "(radio.spectral_scan_interval_seconds is 0)."
+            ),
+        }
+
+    if _scan_service is None:
+        return {
+            "enabled": True,
+            "supported": False,
+            "running": False,
+            "interval_seconds": interval,
+            "frequency_hz": frequency_hz,
+            "bandwidth_khz": bandwidth_khz,
+            "scans_run": 0,
+            "scans_failed": 0,
+            "histogram": None,
+            "message": (
+                "Spectral scan not available on this hardware or HAL build. "
+                "Noise floor uses packet-derived fallback."
+            ),
+        }
+
+    return {
+        "enabled": True,
+        "supported": _scan_service.hardware_supported,
+        "running": _scan_service.is_running,
+        "interval_seconds": interval,
+        "frequency_hz": frequency_hz,
+        "bandwidth_khz": bandwidth_khz,
+        "scans_run": _scan_service.scans_run,
+        "scans_failed": _scan_service.scans_failed,
+        "histogram": _scan_service.histogram_payload(),
+        "message": None,
+    }
+
+
+@router.get("/status")
+async def rf_status() -> dict:
+    """Noise-floor state and latest spectral-scan histogram for the RF tab."""
+    noise_floor = _tracker.snapshot() if _tracker else {}
+    return {
+        "noise_floor": noise_floor,
+        "spectral_scan": _spectral_status(),
+    }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -50,6 +50,7 @@ from src.api.routes import (
     nodes,
     packets,
     public_radar_routes,
+    rf_routes,
     stats_routes,
     system_config_routes,
     system_metrics,
@@ -280,6 +281,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(meshcore_config_routes.router, dependencies=protected)
     app.include_router(config_routes.router, dependencies=protected)
     app.include_router(stats_routes.router, dependencies=protected)
+    app.include_router(rf_routes.router, dependencies=protected)
 
     @app.websocket("/ws")
     async def websocket_endpoint(websocket: WebSocket):
@@ -1235,6 +1237,12 @@ def _init_routes(
         relay_manager=coord.relay_manager,
         node_repo=coord.node_repo,
         packet_repo=coord.packet_repo,
+    )
+    global _spectral_scan_service
+    rf_routes.init_routes(
+        noise_floor_tracker,
+        _spectral_scan_service,
+        config,
     )
 
     meshcore_tx = None

--- a/src/api/telemetry/spectral_scan_service.py
+++ b/src/api/telemetry/spectral_scan_service.py
@@ -86,6 +86,7 @@ class SpectralScanService:
         self._stopped = asyncio.Event()
         self._scans_run = 0
         self._scans_failed = 0
+        self._last_result: Optional[SpectralScanResult] = None
 
     @property
     def scans_run(self) -> int:
@@ -94,6 +95,29 @@ class SpectralScanService:
     @property
     def scans_failed(self) -> int:
         return self._scans_failed
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    @property
+    def hardware_supported(self) -> bool:
+        return self._wrapper.spectral_scan_supported
+
+    def histogram_payload(self) -> dict | None:
+        """Serialise the most recent scan histogram for the RF dashboard."""
+        result = self._last_result
+        if result is None:
+            return None
+        return {
+            "levels_dbm": list(result.levels_dbm),
+            "counts": list(result.counts),
+            "total_samples": result.total_samples,
+            "floor_dbm": result.floor_dbm,
+            "median_dbm": result.median_dbm,
+            "frequency_hz": result.frequency_hz,
+            "timestamp": result.timestamp,
+        }
 
     async def start(self) -> None:
         """Begin the periodic-scan loop.
@@ -163,6 +187,7 @@ class SpectralScanService:
         self._publish(result)
 
     def _publish(self, result: SpectralScanResult) -> None:
+        self._last_result = result
         floor = result.floor_dbm
         median = result.median_dbm
         if floor is None or median is None:

--- a/tests/test_rf_routes.py
+++ b/tests/test_rf_routes.py
@@ -1,0 +1,95 @@
+"""Tests for GET /api/rf/status."""
+from __future__ import annotations
+
+import time
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.telemetry.noise_floor import NoiseFloorTracker, SOURCE_PACKETS
+from src.api.telemetry.spectral_scan_service import SpectralScanService
+from src.api.routes import rf_routes
+from src.config import AppConfig, RadioConfig
+from src.hal.sx1302_spectral_scan import SpectralScanResult
+
+
+class _FakeWrapper:
+    spectral_scan_supported = True
+
+    def run_spectral_scan(self, frequency_hz: int, nb_scan: int = 1024):
+        return None
+
+
+def _histogram_result() -> SpectralScanResult:
+    levels = tuple([-120 + i * 2 for i in range(35)])
+    counts = tuple([0] * 34 + [40])
+    return SpectralScanResult(
+        levels_dbm=levels,
+        counts=counts,
+        frequency_hz=906_875_000,
+        nb_scan=1024,
+        timestamp=time.time(),
+    )
+
+
+class TestRfRoutes(unittest.TestCase):
+    def _client(
+        self,
+        *,
+        interval: float = 60.0,
+        scan_service: SpectralScanService | None = None,
+    ) -> TestClient:
+        tracker = NoiseFloorTracker()
+        config = AppConfig(radio=RadioConfig(spectral_scan_interval_seconds=interval))
+        rf_routes.init_routes(tracker, scan_service, config)
+        app = FastAPI()
+        app.include_router(rf_routes.router)
+        return TestClient(app)
+
+    def test_status_returns_noise_floor_snapshot(self) -> None:
+        tracker = NoiseFloorTracker()
+        tracker.update(rssi_dbm=-90, snr_db=8, bandwidth_khz=250)
+        tracker.update(rssi_dbm=-88, snr_db=6, bandwidth_khz=250)
+        config = AppConfig(radio=RadioConfig(spectral_scan_interval_seconds=0))
+        rf_routes.init_routes(tracker, None, config)
+        app = FastAPI()
+        app.include_router(rf_routes.router)
+        client = TestClient(app)
+
+        res = client.get("/api/rf/status")
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        self.assertEqual(body["noise_floor"]["source"], SOURCE_PACKETS)
+        self.assertFalse(body["spectral_scan"]["enabled"])
+        self.assertIsNone(body["spectral_scan"]["histogram"])
+
+    def test_scan_disabled_message_when_interval_zero(self) -> None:
+        client = self._client(interval=0)
+        body = client.get("/api/rf/status").json()
+        self.assertIn("interval_seconds is 0", body["spectral_scan"]["message"])
+
+    def test_histogram_exposed_after_scan(self) -> None:
+        wrapper = _FakeWrapper()
+        wrapper.run_spectral_scan = lambda *_a, **_k: _histogram_result()  # type: ignore[method-assign]
+        tracker = NoiseFloorTracker()
+        service = SpectralScanService(
+            wrapper=wrapper,
+            tracker=tracker,
+            frequency_hz=906_875_000,
+            bandwidth_khz=250,
+            interval_seconds=5,
+            startup_delay_seconds=0,
+        )
+        service._publish(_histogram_result())
+
+        client = self._client(scan_service=service)
+        body = client.get("/api/rf/status").json()
+        hist = body["spectral_scan"]["histogram"]
+        self.assertIsNotNone(hist)
+        self.assertEqual(len(hist["levels_dbm"]), 35)
+        self.assertGreater(hist["total_samples"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `GET /api/rf/status` exposing `NoiseFloorTracker` snapshot and spectral-scan service state (enabled/supported/running, scan counters, latest histogram).
- Retain the most recent scan histogram on `SpectralScanService` for the RF dashboard (no new HAL code).
- Add **RF Environment** sidebar tab with noise-floor sparkline, live vs packet-fallback badges, calibration state, and Chart.js spectral histogram.

## Test plan
- [x] `python -m unittest tests.test_rf_routes tests.test_spectral_scan_service -v` (7 passed)
- [ ] Open RF Environment tab — noise floor readout and sparkline populate
- [ ] With `spectral_scan_interval_seconds: 0` — tab shows disabled scan message, packet fallback badge
- [ ] On hardware with scan enabled — histogram renders after first scan; badge shows Live scan
- [ ] Sidebar telemetry rail still works independently

## AI disclosure
Implemented with Cursor AI assistance; reviewed and tested locally.