### PR TITLE
feat(admin): remote Meshtastic node config write (limited fields)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,6 +11,11 @@ radio:
   sync_word: 0x2B
   preamble_length: 16
   tx_power_dbm: 22
+  # HAL GPS/PPS (RAK Pi HAT u-blox → concentrator PPS pin). Off by default.
+  # gps_pps_enabled: false
+  # gps_pps_tty_path: "/dev/ttyAMA0"
+  # gps_family: "ubx7"
+  # gps_pps_target_baud: 0   # 0 = HAL default (9600)
 
 meshtastic:
   default_key_b64: "AQ=="
@@ -19,6 +24,9 @@ meshtastic:
   #   MyChannel: "base64encodedPSK=="
   #   SecretChat: "anotherBase64PSK=="
   channel_keys: {}
+  # Remote ADMIN config read (PR 15) — PSK for the shared admin channel on target nodes.
+  # admin_key_b64: "base64PSK=="
+  # admin_channel_name: "admin"
 
 meshcore:
   default_key_b64: ""
@@ -50,7 +58,7 @@ device:
   longitude: 0.0
   altitude: 25
   hardware_description: "RAK2287 + Raspberry Pi 4"
-  firmware_version: "0.7.6"
+  firmware_version: "0.7.5.1"
 
 relay:
   enabled: false
@@ -60,6 +68,18 @@ relay:
   burst_size: 5
   min_relay_rssi: -110.0
   max_relay_rssi: -50.0
+  # blocklist: []         # 8-char hex node IDs — relay only, feed unchanged
+  # priority_list: []     # bypass burst gate under congestion
+  # dedup_ttl_seconds: 300
+  # channel_throttle_percent:   # per-channel relay duty budget (est. ToA)
+  #   "0": 100                  # omit = 100% all channels; EU capped at 1%
+  # storm_guard:                # memory-only quarantine (PR 12)
+  #   enabled: false
+  #   window_seconds: 60
+  #   identical_packet_threshold: 5
+  #   rate_threshold_per_minute: 30
+  #   quarantine_duration_seconds: 300
+  #   notify_dashboard: true
 
 upstream:
   enabled: true
@@ -80,13 +100,6 @@ transmit:
   nodeinfo:
     interval_minutes: 180      # 5..1440 min, default 180 (3 hr); 0 = disabled
     startup_delay_seconds: 60  # delay before first broadcast on boot
-  position:
-    interval_minutes: 15
-    startup_delay_seconds: 180
-    # LoRa mesh POSITION packets (Meshtastic app map). Meshradar fleet pin
-    # always uses device.latitude/longitude above, not live GPS.
-    coordinate_source: "static"   # static | live (live needs gpsd/uart source)
-    location_precision: "approximate"  # exact | approximate | none (live only)
 
 web_auth:
   # First-run state: hashes are empty -> dashboard forces /setup.
@@ -124,18 +137,29 @@ mqtt:
   homeassistant_discovery: false
 
 location:
-  # Where live GPS fixes come from (skyplot + optional mesh POSITION).
-  # Registered coordinates for Meshradar live in device.latitude/longitude
-  # and are not overwritten by gpsd.
+  # Where the Meshpoint's reported lat/lon/alt comes from.
   #   static : use device.latitude/longitude/altitude (default)
   #   gpsd   : poll a local or remote gpsd daemon for live fixes
-  #   uart   : reserved (RAK Pi HAT GPS, not yet wired)
+  #   uart   : on-board RAK Pi HAT GPS via /dev/ttyAMA0 (NMEA GGA)
   source: "static"
   # gpsd connection. Defaults match the well-known local socket; only
   # change when running gpsd on a peer machine on the LAN.
   gpsd_host: "127.0.0.1"
   gpsd_port: 2947
+  uart_path: "/dev/ttyAMA0"
+  uart_baud: 9600
   # How often the coordinator wakes to read the active source.
   update_interval_seconds: 5
   # Minimum acceptable fix mode: 0=any (incl. no-fix), 1=2D, 2=3D.
   min_fix_quality: 1
+
+# signal_health:
+#   green_rssi_floor: -100    # badge green when 1h avg RSSI is above this
+#   yellow_rssi_floor: -115   # badge yellow above this, red below
+#   min_packets_per_hour: 5   # hide badge when fewer packets in the last hour
+
+# automation:
+#   enabled: false
+#   # Long random secret for LAN scripts (Home Assistant, Node-RED). Generate with:
+#   #   openssl rand -hex 32
+#   token: ""

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,7 @@ radio:
   tx_power_dbm: 22             # SX1302 concentrator output power
   spectral_scan_interval_seconds: 60   # noise floor sampler cadence (0 disables)
   sx1261_spi_path: ""          # SX1261 SPI device for spectral scan (empty = disabled)
+  carrier_type: ""             # rak | sensecap_m1 (set by meshpoint setup; guards SX1261 path)
 ```
 
 The region sets the base frequency, spreading factor, and bandwidth automatically. You only need `region` in most cases. Override `frequency_mhz`, `spreading_factor`, or `bandwidth_khz` individually to tune for non-default presets (MediumFast, ShortFast, etc.) or custom frequency slots.
@@ -76,7 +77,37 @@ ERROR: failed to patch sx1261 radio for LBT/Spectral Scan
 
 …and `lgw_start()` may then refuse to bring up the concentrator. If you see that, revert `sx1261_spi_path` to `""`, restart the service, and stay on the packet-derived fallback.
 
+On RAK and SenseCap carriers, `meshpoint setup` writes `radio.carrier_type`. When that field is `rak` or `sensecap_m1`, Meshpoint **clears** a non-empty `sx1261_spi_path` at startup and logs a warning instead of calling `lgw_sx1261_setconf`.
+
 If your `libloragw` build does not expose the spectral scan symbols at all (older HAL revisions), the service logs a single info line at startup and falls back automatically.
+
+### GPS PPS time sync (HAL)
+
+Separate from [Location (GPS) source](#location-gps-source) (dashboard lat/lon). PPS sync wires the concentrator's internal packet counter to GPS time via Semtech `lgw_gps_*` and `sx1302_gps_enable` — useful when you need accurate `timestamp_us` on RX metadata (logging, TDoA-style analysis, correlating captures to wall clock).
+
+```yaml
+radio:
+  gps_pps_enabled: false          # set true on RAK Pi HAT with PPS wired to SX1303
+  gps_pps_tty_path: "/dev/ttyAMA0"
+  gps_family: "ubx7"              # passed to lgw_gps_enable
+  gps_pps_target_baud: 0           # 0 = HAL default (9600)
+```
+
+Requirements:
+
+- `libloragw` built from the SX1302 HAL tree with `loragw_gps.c` linked (stock `lora_gateway` packages on some images omit these symbols — startup logs `GPS/PPS sync unavailable` and continues).
+- u-blox on the HAT UART with PPS routed to the concentrator (RAK2287/5146/SX1303 HAT).
+- Clear sky: first `lgw_gps_sync` may take minutes until UBX time messages arrive.
+
+**Do not** enable `gps_pps_enabled` and `location.source: uart` on the same `tty_path`. Only one owner can open the serial port. Typical RAK deployments:
+
+| Goal | `location.source` | `radio.gps_pps_enabled` |
+|---|---|---|
+| Map position from HAT GPS | `uart` | `false` |
+| Accurate packet timestamps + map from USB gpsd | `gpsd` | `true` on `/dev/ttyAMA0` |
+| Timestamps only, static map coords | `static` | `true` |
+
+Status: `GET /api/device/gps-pps-status` (enabled, sync count, last error, reference counter). Config keys also appear under `radio_advanced` in `GET /api/config`.
 
 ### Standard Meshtastic Presets
 
@@ -160,6 +191,47 @@ The setup wizard configures sources automatically. To add or remove a MeshCore c
 
 When running both Meshtastic concentrator capture and a MeshCore USB companion, pin `meshcore_usb.serial_port` explicitly. Auto-detect can grab the wrong device when multiple Espressif boards are attached.
 
+### Companion firmware flash (dashboard)
+
+**Settings → System → Flash companion firmware** uploads a `.bin` and runs `esptool` against the USB companion. MeshCore USB capture releases the serial port during the flash; the existing auto-reconnect loop restores the connection after the ESP reboots (~5–15 s).
+
+- Admin-only; every attempt is audit-logged (`firmware_flash`).
+- Default port comes from `capture.meshcore_usb.serial_port` (falls back to `/dev/ttyUSB0`).
+- Default partition offset `0x10000` (typical MeshCore/Meshtastic app slot — verify for your board).
+- Requires `esptool>=4.7.0` (installed with Meshpoint dependencies).
+- **Not** OTA over LoRa — local USB only.
+
+### Remote node config read (ADMIN, read-only)
+
+**Node drawer → Remote Configuration** sends a single encrypted ADMIN `get_config_request` (or `get_owner_request`) per click. Responses display read-only in the drawer. Requires native TX (`transmit.enabled: true`) and a shared admin channel PSK on target nodes.
+
+```yaml
+meshtastic:
+  admin_key_b64: "base64PSK=="   # PSK for the shared "admin" channel
+  admin_channel_name: "admin"    # optional; default "admin"
+```
+
+- Admin-only API; audit action `admin.config_request` (target node + section only — no PSK in logs).
+- 30 s response timeout with retry UI; 30 s debounce between requests per node.
+- **Read-only** — use write path below for limited field updates.
+
+### Remote node config write (ADMIN, limited fields)
+
+**Node drawer → Remote Configuration → Apply changes** sends allow-listed ADMIN writes:
+
+| Field | Limit |
+|-------|-------|
+| `long_name` / `short_name` | 40 / 4 chars |
+| `role` | CLIENT, ROUTER, REPEATER, etc. — requires typing `CONFIRM` in modal |
+| `screen_on_secs` | 0–600 |
+| `telemetry_interval_secs` | 30–86400 |
+
+**Not writable:** LoRa frequency, PSK/security, factory reset, or other ADMIN commands.
+
+- Admin-only; audit action `admin.config_write` (changes only — no secrets).
+- Post-write automatic config read verifies the applied state.
+- 30 s debounce between writes per node.
+
 ---
 
 ## Location (GPS) source
@@ -169,52 +241,31 @@ location:
   source: "static"           # static | gpsd | uart
   gpsd_host: "127.0.0.1"     # gpsd TCP host (only when source=gpsd)
   gpsd_port: 2947            # gpsd TCP port
+  uart_path: "/dev/ttyAMA0"  # serial device (only when source=uart)
+  uart_baud: 9600            # NMEA baud (uart only)
   update_interval_seconds: 5 # how often the coordinator polls the source
-  min_fix_quality: 1         # minimum NMEA fix quality (1=2D, 3=3D)
+  min_fix_quality: 1         # minimum fix quality (1=2D, 2=3D for gpsd/uart)
 ```
 
-`location.source` selects where the Meshpoint reads **live GPS fixes**
-(for the Configuration → GPS skyplot and optional mesh POSITION
-broadcasts). The setup wizard always writes static lat/lon/alt under
-`device.*` as the **registered Meshradar fleet pin** (see
-[Device Identity](#device-identity)); live gpsd does **not** overwrite
-those values. Source changes require a service restart; registered
-coordinates and mesh position settings hot-reload from the dashboard.
+`location.source` selects where the Meshpoint reads its current
+position. The setup wizard always writes static lat/lon/alt under
+`device.*` (see [Device Identity](#device-identity)); the choice
+here is whether to **also** consult a live GPS at runtime. Source
+changes require a service restart; everything else hot-reloads.
 
 | Source | Behavior |
 |---|---|
-| `static` (default) | No live GPS hardware. Registered coordinates live in `device.*` only. Skyplot shows the static pin. |
-| `gpsd` | Reads live fixes from the system `gpsd` daemon over TCP (`127.0.0.1:2947`). Recommended for any USB GPS receiver (u-blox 7, u-blox 8, VFAN puck, generic CDC ACM sticks). Skyplot and stats update from the live fix. |
-| `uart` | Reserved for direct-serial reads from a Pi HAT GPS (e.g. RAK 7248). Currently a placeholder; falls back to static and surfaces an explanatory error in the dashboard. |
+| `static` (default) | Uses `device.latitude` / `device.longitude` / `device.altitude` exactly as set during the wizard. No GPS hardware required. |
+| `gpsd` | Reads live fixes from the system `gpsd` daemon over TCP (`127.0.0.1:2947`). Recommended for any USB GPS receiver (u-blox 7, u-blox 8, VFAN puck, generic CDC ACM sticks). |
+| `uart` | Reads NMEA GGA from the on-board RAK Pi HAT GPS on `/dev/ttyAMA0` (or `uart_path`). Fix and satellite count update live; full skyplot az/el/SNR needs `gpsd` + USB receiver. |
 
-### Mesh position broadcasts (LoRa / Meshtastic app map)
-
-When native TX is enabled (`transmit.enabled: true`), the Meshpoint can
-send periodic Meshtastic POSITION packets. That is **separate** from
-the Meshradar fleet pin in `device.*`.
-
-Configure on **Configuration → GPS → Mesh position broadcasts**, or in
-yaml:
-
-```yaml
-transmit:
-  position:
-    interval_minutes: 15
-    startup_delay_seconds: 180
-    coordinate_source: "static"       # static | live
-    location_precision: "approximate"  # exact | approximate | none (live only)
-```
-
-| Setting | Values | Meaning |
-|---|---|---|
-| `coordinate_source` | `static` (default) | Broadcast the registered pin from `device.latitude/longitude`. |
-| | `live` | Broadcast the live gpsd/UART fix. Requires `location.source` other than `static`. |
-| `location_precision` | `approximate` (default for live) | Round to ~2 decimal places before POSITION TX (about **0.7 mi** / **1.1 km**; the dashboard label follows Settings → Meshpoint distance units). |
-| | `exact` | Full precision from the live fix. |
-| | `none` | Skip POSITION broadcasts when using live (privacy: no position on mesh). |
-
-When `coordinate_source: static`, coordinates are sent at full wizard
-precision regardless of `location_precision`.
+When `source` is `gpsd` or `uart` and a 2D or 3D fix is available,
+the coordinator updates `_config.device.latitude` / `.longitude` /
+`.altitude` in place every `update_interval_seconds`. Anything that
+reads from `device.*` (NodeInfo broadcasts, MQTT, the dashboard map,
+Meshradar cloud) automatically sees the live position. If the fix
+is lost, the last known coordinates remain in use until a fresh fix
+arrives — there is no fallback to the wizard-time static value.
 
 ### Using gpsd (USB GPS receivers)
 
@@ -231,12 +282,10 @@ To enable live GPS:
    The MeshCore USB auto-detect path (`UsbPortClassifier`) skips
    any port classified as `gps_known`, so a u-blox stick will
    never be probed as a MeshCore companion.
-2. Open the dashboard at **Configuration → GPS**. Set **Registered
-   coordinates** (Meshradar fleet pin). Switch **Source** to **gpsd**
-   for live skyplot data. Optionally set **Mesh position broadcasts**
-   to **Live GPS** with **Approximate** or **Precise** privacy, then
-   click **Save**. Changing the GPS source type requires a service
-   restart; coordinate and mesh-position edits hot-reload.
+2. Open the dashboard at **Configuration → GPS**, switch the source
+   to **gpsd**, and click **Save**. The Meshpoint restarts the
+   location source in-place; no full service restart needed unless
+   you also changed `gpsd_host` / `gpsd_port`.
 3. Watch the **GPS** card. The skyplot animates, satellite dots
    render at their azimuth/elevation, and the fix-mode lamp flips
    from grey (no fix) → amber (2D) → green (3D) as the receiver
@@ -253,28 +302,45 @@ in `gpsd-clients`) or `gpsmon`.
 | u-blox 7 USB stick | USB CDC ACM, NMEA + UBX | yes (RAK V2 .141) |
 | u-blox 8 USB stick | USB CDC ACM, NMEA + UBX | yes |
 | VFAN ublox 7 USB puck | USB CDC ACM, NMEA + UBX | yes |
-| RAK 7248 onboard u-blox via UART (`/dev/ttyAMA0`) | NMEA over UART | placeholder (`source: uart`, not yet wired) |
+| RAK 7248 onboard u-blox via UART (`/dev/ttyAMA0`) | NMEA over UART | yes (`source: uart`; `install.sh` enables UART) |
 
 Other USB receivers should work as long as `gpsd` recognizes the
 device's VID. If `cgps` shows data but the dashboard does not,
 check `journalctl -u meshpoint | grep -i gpsd` for connection
 errors and confirm `source: gpsd` in `local.yaml`.
 
+### Using uart (RAK Pi HAT onboard GPS)
+
+`scripts/install.sh` enables the primary UART (`/dev/ttyAMA0`), disables
+the serial console, and turns off Bluetooth on the UART pins so the HAT
+GPS module can talk to the Pi.
+
+1. Run `sudo meshpoint setup` outdoors and accept **Use live UART GPS**
+   when the wizard acquires a fix, **or** set in `local.yaml`:
+
+   ```yaml
+   location:
+     source: "uart"
+     uart_path: "/dev/ttyAMA0"
+     uart_baud: 9600
+   ```
+
+2. Restart: `sudo systemctl restart meshpoint`.
+
+3. Open **Configuration → GPS** → **UART**. Coordinates and satellite
+   count update every few seconds outdoors. The skyplot stays empty
+   until GSV parsing is added (use `gpsd` for a full skyplot today).
+
 ### Privacy
 
-Three independent surfaces:
-
-| Surface | Config | Notes |
-|---|---|---|
-| **Meshradar cloud** | `device.latitude/longitude` | Always the registered pin. Live GPS never moves the fleet marker. |
-| **LoRa mesh (POSITION)** | `transmit.position.coordinate_source` + `location_precision` | Choose registered pin or live GPS; approximate / precise / hidden on live. |
-| **MQTT** | `mqtt.location_precision` | Applies to position fields in MQTT publishes only (`exact` / `approximate` / `none`). |
-
-To run a mobile Meshpoint without leaking live coordinates on the mesh,
-use **Live GPS** with **Hidden** mesh privacy, or keep mesh source on
-**Registered pin**. To keep Meshradar on your home pin while testing
-gpsd outdoors, leave registered coordinates at home and use live mesh
-POSITION only if you intend to advertise on the LoRa map.
+Live GPS coordinates flow through the same surfaces as the static
+wizard values: NodeInfo broadcasts (off-air to the mesh), MQTT
+(only when `mqtt.enabled: true` and the channel is allow-listed,
+respecting `mqtt.location_precision`), and the upstream WebSocket
+to meshradar.io (only when `upstream.enabled: true`). To run a
+mobile / wardriving Meshpoint without leaking position upstream,
+either `mqtt.location_precision: none` (or `approximate`) or
+`upstream.enabled: false`.
 
 ---
 
@@ -288,6 +354,15 @@ meshtastic:
 ```
 
 The default is `LongFast` (Meshtastic's standard public channel). Change it only if your mesh uses a custom primary channel name. You can also edit this from the dashboard: open the **Radio** tab, edit **Channel 0**, and save. The Radio and Messages tabs reflect the same value.
+
+### Quick Deploy (QR export)
+
+**Configuration → Channels → Quick Deploy** exports public channel parameters for field radios:
+
+- QR code and `https://meshtastic.org/e/#…` URL (Meshtastic app compatible)
+- Downloadable JSON via `GET /api/config/export`
+
+**Private channel keys are never exported.** The QR uses the standard Meshtastic default PSK only (`AQ==`), matching a public primary channel deployment. Scan with the Meshtastic mobile app (Android in-app scanner; iOS camera).
 
 ---
 
@@ -405,6 +480,36 @@ relay:
 
 The relay path is independent from RX: transmission never blocks packet reception. Packets are deduplicated by ID, rate-limited, and filtered by signal strength before relay.
 
+### Per-channel relay throttle (est.)
+
+Optional rolling 1-hour ToA budget per Meshtastic channel index. **Relay TX only** — does not change native `transmit` messaging. Omitted channels default to 100% (today's behaviour).
+
+```yaml
+relay:
+  channel_throttle_percent:
+    "0": 100
+    "1": 50
+```
+
+On EU868 the effective ceiling is capped at the 1% regional hint regardless of slider value. Values are **estimates** (same ToA math as the Stats traffic chart), not spectrum-analyser measurements. Configure from **Configuration → Advanced → Relay filters** or edit `local.yaml`.
+
+### Storm guard quarantine (memory-only)
+
+Temporary relay blocks for replay storms or excessive per-node packet rates. **Does not write to SQLite** and is separate from the permanent YAML blocklist (PR 13). Quarantined nodes still appear in the live packet feed; only relay TX is blocked. Auto-releases after `quarantine_duration_seconds`. Operators can release early or promote to blocklist from **Configuration → Advanced**.
+
+```yaml
+relay:
+  storm_guard:
+    enabled: true
+    window_seconds: 60
+    identical_packet_threshold: 5   # same packet_id N times in window
+    rate_threshold_per_minute: 30   # packets from one node in window
+    quarantine_duration_seconds: 300
+    notify_dashboard: true          # WS alert + push notification toggle
+```
+
+**Interaction with other filters:** blocklist is checked first (permanent deny). Storm guard runs next (temporary deny). `channel_throttled` and `rate_limited` apply only after a packet passes blocklist and quarantine. Busy legitimate nodes can false-positive if thresholds are too low — tune `rate_threshold_per_minute` for your mesh density.
+
 ---
 
 ## Transmit (Native Messaging)
@@ -477,6 +582,100 @@ storage:
 
 Packets are stored in a local SQLite database. Old packets are pruned automatically based on `max_packets_retained`.
 
+### Stray frames (Unknown RF)
+
+When a LoRa frame fails **both** Meshtastic and MeshCore decode, Meshpoint can log RF metadata only (no relay, no re-encode). View results in the dashboard **Unknown RF** tab or export via `GET /api/stray_frames?format=csv`.
+
+```yaml
+stray_frames:
+  enabled: true
+  max_retained: 10000      # hard cap on SQLite rows
+  retention_hours: 168       # drop rows older than this (7 days)
+```
+
+Pruning runs in the background during the normal storage cleanup loop and does not block the receive path.
+
+### Prometheus metrics (`/metrics`)
+
+Optional Prometheus text scrape endpoint for LAN monitoring. **Off by default** — enabling does not change packet capture, relay, or dashboard behaviour.
+
+```yaml
+metrics:
+  enabled: false
+  require_auth: true    # when false, /metrics is open on the LAN (use firewall rules)
+```
+
+When `metrics.enabled: true`, Prometheus (or any scraper) can poll:
+
+```text
+http://<pi-ip>:8080/metrics
+```
+
+Exposed series include packet counts, node totals, RSSI/SNR averages, noise floor, relay stats, per-channel duty estimates (ToA), SX1302 CRC counters, and process uptime. Labels use protocol/channel/reason only — never PSKs, tokens, or node secrets.
+
+**Example `prometheus.yml` scrape job (auth disabled):**
+
+```yaml
+scrape_configs:
+  - job_name: meshpoint
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["192.168.1.50:8080"]
+    metrics_path: /metrics
+```
+
+When `require_auth: true`, configure your scraper to send the dashboard session cookie or Bearer JWT (same as other protected API routes).
+
+### Webhooks (outbound HTTP)
+
+Fire async HTTP POSTs to LAN services (Home Assistant, Node-RED, Slack-compatible hooks) when mesh events occur. **Off by default.** Failures are logged to the admin audit log and never block packet processing.
+
+```yaml
+webhooks:
+  enabled: false
+  rules:
+    - name: low-battery-ha
+      url: "http://192.168.1.10:8123/api/webhook/mesh_low_battery"
+      event: battery_low
+      cooldown_seconds: 3600
+      battery_threshold_percent: 20
+    - name: sos-keyword
+      url: "https://hooks.example.com/sos"
+      event: keyword_match
+      keyword: "SOS"
+      cooldown_seconds: 300
+    - name: node-return
+      url: "http://192.168.1.10:8123/api/webhook/mesh_online"
+      event: node_online
+      cooldown_seconds: 600
+    - name: node-silent
+      url: "http://192.168.1.10:8123/api/webhook/mesh_offline"
+      event: node_offline
+      cooldown_seconds: 7200
+    - name: relay-duty-high
+      url: "http://192.168.1.10:8123/api/webhook/mesh_duty"
+      event: duty_spike
+      duty_threshold_percent: 80
+      cooldown_seconds: 1800
+```
+
+**Supported events:**
+
+| Event | When it fires |
+|-------|----------------|
+| `battery_low` | Telemetry reports at or below `battery_threshold_percent` (default 20%) |
+| `node_offline` | Node not heard for 2+ hours (same window as dashboard online dot) |
+| `node_online` | Node heard again after being offline |
+| `keyword_match` | Decoded text message contains `keyword` (case-insensitive) |
+| `duty_spike` | Aggregate relay duty (ToA estimate) exceeds `duty_threshold_percent` |
+| `storm_quarantine` | Reserved for a future release (PR 12); validates at startup but does not fire yet |
+
+Each rule has a per-rule cooldown (per node for node/battery/keyword events). POST body is JSON with `event`, `rule`, `device_name`, `timestamp`, optional `node_id`, and a `data` object — no PSKs or channel keys.
+
+Webhook fires are appended to `data/admin_audit.jsonl` as `webhook.fire` entries.
+
+**Dashboard:** **Configuration → Advanced → Webhooks** lists configured rules, last-fired timestamps, and a **Test** button that sends a dummy POST (`event: test`) to verify each URL from the Pi.
+
 ---
 
 ## Dashboard
@@ -489,6 +688,57 @@ dashboard:
 ```
 
 Access at `http://<pi-ip>:8080`. Bind to `127.0.0.1` to restrict to local access only.
+
+### RF Environment tab
+
+Open **RF Environment** in the sidebar for a full-page noise-floor sparkline, calibration state, and the latest SX1302 spectral-scan histogram. Data comes from `GET /api/rf/status` (same sources as the sidebar telemetry rail).
+
+- **Live scan** — hardware spectral scan on the tuned channel (`radio.spectral_scan_interval_seconds` > 0 and SX1261/HAL support present)
+- **Packet fallback** — rolling minimum of `RSSI − SNR` when scan is disabled or unavailable
+- Set `radio.spectral_scan_interval_seconds: 0` in **Configuration → Advanced** to disable hardware scan; the tab shows a clear message and uses packet fallback only
+
+### Unknown RF tab
+
+Open **Unknown RF** in the sidebar to browse undecodable frames logged by `stray_frames` (see Storage). Filter by time window and minimum RSSI; use **Export CSV** to download the current filter via `/api/stray_frames?format=csv`. Disable logging with `stray_frames.enabled: false` in `local.yaml`.
+
+### Coverage View (map)
+
+On the **Dashboard → Node Map**, open the Leaflet layer control (top-right) and enable **Coverage View**. Plotted nodes with GPS show RSSI-colored circles (green/cyan/yellow/red by average signal). Circle size reflects recent packet volume (confidence). Nodes without coordinates appear in the **unplotted** count beside the map title. Click any marker or coverage circle to open the node drawer. **Topology Links** remains a separate overlay and can be used together with coverage.
+
+### Browser notifications
+
+**Settings → System → Browser notifications** enables LAN push alerts while any authenticated dashboard tab is open. Preferences are stored in the browser (`localStorage`), not on the device.
+
+Supported alert types:
+
+- **Node offline** — not heard for 2+ hours (matches the node-card online dot)
+- **Node back online** — heard again after being offline
+- **Low battery** — telemetry reports ≤20% (one alert per node per hour)
+- **Storm guard** — reserved for a future release; toggle is present but inactive until storm-guard quarantine ships
+
+Grant notification permission when prompted. Use **Suppress when this tab is focused** to avoid duplicate toasts while you are actively watching the dashboard.
+
+---
+
+## LAN Automation API
+
+Optional REST endpoints for Home Assistant, Node-RED, and other LAN scripts. **Off by default** — enabling does not change dashboard behaviour.
+
+```yaml
+automation:
+  enabled: false
+  token: ""   # required when enabled; use 32+ random characters
+```
+
+Generate a token:
+
+```bash
+openssl rand -hex 32
+```
+
+Add the `automation` block to `config/local.yaml`, set `enabled: true`, paste the token, and restart Meshpoint. Scripts authenticate with `X-Meshpoint-Token: <token>` or `Authorization: Bearer <token>`.
+
+**Security:** use only on a trusted LAN. Do not port-forward the dashboard port. See [API-AUTOMATION.md](API-AUTOMATION.md) for endpoint reference and copy-paste Home Assistant examples.
 
 ---
 
@@ -602,7 +852,7 @@ Control how much location detail leaves the device via MQTT:
 | Value | Behavior |
 |---|---|
 | `exact` | Full GPS coordinates (default) |
-| `approximate` | Rounded to ~2 decimal places (about 0.7 mi / 1.1 km; Configuration → MQTT and GPS labels follow Settings → Meshpoint distance units) |
+| `approximate` | Rounded to ~1.1km precision (2 decimal places) |
 | `none` | Location stripped entirely from MQTT messages |
 
 Full-precision location data is always available on the [Meshradar](https://meshradar.io) dashboard regardless of this setting.
@@ -693,6 +943,8 @@ location:              # GPS / location source
   source: "static"            # static | gpsd | uart
   gpsd_host: "127.0.0.1"
   gpsd_port: 2947
+  uart_path: "/dev/ttyAMA0"
+  uart_baud: 9600
   update_interval_seconds: 5
   min_fix_quality: 1
 
@@ -704,10 +956,6 @@ transmit:              # native messaging TX (Meshtastic via SX1302, MeshCore vi
   long_name: "Meshpoint"
   short_name: "MPNT"
   hop_limit: 3
-  position:
-    interval_minutes: 15
-    coordinate_source: "static"      # static | live
-    location_precision: "approximate"  # exact | approximate | none (live only)
 
 relay:                 # experimental: re-broadcast captured packets via USB radio
   enabled: false
@@ -717,6 +965,7 @@ relay:                 # experimental: re-broadcast captured packets via USB rad
   burst_size: 5
   min_relay_rssi: -110.0
   max_relay_rssi: -50.0
+  channel_throttle_percent: {}  # per-channel relay ToA budget (est.); omit = 100%
 
 upstream:              # cloud (Meshradar) connection
   enabled: true
@@ -744,10 +993,27 @@ storage:               # local SQLite packet store
   max_packets_retained: 100000
   cleanup_interval_seconds: 3600
 
+stray_frames:          # undecodable RF metadata (Unknown RF tab)
+  enabled: true
+  max_retained: 10000
+  retention_hours: 168
+
+metrics:               # Prometheus /metrics scrape (off by default)
+  enabled: false
+  require_auth: true
+
+webhooks:              # outbound HTTP on mesh events (off by default)
+  enabled: false
+  rules: []
+
 dashboard:             # local web UI
   host: "0.0.0.0"
   port: 8080
   static_dir: "frontend"
+
+automation:             # LAN REST API for scripts (off by default)
+  enabled: false
+  token: ""
 ```
 
 You only need to put the keys you want to override into `local.yaml`. Every key omitted from `local.yaml` falls back to the value in `config/default.yaml`.

--- a/frontend/css/node_drawer.css
+++ b/frontend/css/node_drawer.css
@@ -322,6 +322,101 @@
     pointer-events: auto;
 }
 
+/* ---- Remote ADMIN config (node drawer) ---- */
+
+.nd-remote-config__toolbar {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.nd-remote-config__select {
+    flex: 1;
+    min-width: 0;
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+}
+
+.nd-remote-config__btn {
+    flex-shrink: 0;
+    font-size: 0.8rem;
+    padding: 0.35rem 0.6rem;
+}
+
+.nd-remote-config__status {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0.5rem;
+}
+
+.nd-remote-config__hint {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.nd-remote-config__hint code {
+    font-size: 0.75rem;
+}
+
+.nd-remote-config__result {
+    max-height: 220px;
+    overflow-y: auto;
+    border-top: 1px solid var(--border);
+    padding-top: 0.35rem;
+}
+
+.nd-remote-config__write {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--border);
+}
+
+.nd-remote-config__write-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+    color: var(--text-primary);
+}
+
+.nd-remote-config__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-bottom: 0.45rem;
+}
+
+.nd-remote-config__input {
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+}
+
+.nd-remote-config__write-btn {
+    width: 100%;
+    margin-top: 0.35rem;
+}
+
+.nd-remote-config__retry {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+    font-size: inherit;
+}
+
 @media (max-width: 480px) {
     .nd-drawer {
         width: 100%;

--- a/frontend/css/terminal.css
+++ b/frontend/css/terminal.css
@@ -637,6 +637,25 @@
     word-break: break-word;
 }
 
+.danger-modal__typed {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+    font-size: 12px;
+    color: rgba(243, 244, 246, 0.75);
+}
+
+.danger-modal__typed-input {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--term-border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    color: #f3f4f6;
+    font-family: 'JetBrains Mono', Menlo, Consolas, monospace;
+    font-size: 13px;
+}
+
 .danger-modal__field {
     display: flex;
     flex-direction: column;

--- a/frontend/js/node_drawer.js
+++ b/frontend/js/node_drawer.js
@@ -11,6 +11,14 @@ class NodeDrawer {
         this._sections = {};
         this._metricsChart = null;
         this._metricsHours = 24;
+        this._adminConfigAvailable = false;
+        this._adminDebounceSeconds = 30;
+        this._adminPollTimer = null;
+        this._adminConfigDebounceUntil = 0;
+        this._adminWritePollTimer = null;
+        this._dangerousModal = window.DangerousModal
+            ? new window.DangerousModal()
+            : null;
 
         if (window.MeshpointNodeFavorites) {
             window.MeshpointNodeFavorites.onChange(() => this._refreshFavoriteButton());
@@ -23,10 +31,15 @@ class NodeDrawer {
         this._renderSkeleton(node);
         this._drawer.classList.add('nd-drawer--open');
 
-        const [detail, metrics] = await Promise.all([
+        const [detail, metrics, adminStatus] = await Promise.all([
             this._fetchDetail(node.node_id),
             this._fetchMetricsHistory(node.node_id, this._metricsHours),
+            this._fetchAdminConfigStatus(),
         ]);
+        if (adminStatus) {
+            this._adminConfigAvailable = !!adminStatus.available;
+            this._adminDebounceSeconds = adminStatus.debounce_seconds || 30;
+        }
 
         const merged = { ...node, ...detail };
         merged._metricsHistory = metrics;
@@ -38,6 +51,8 @@ class NodeDrawer {
     }
 
     close() {
+        this._stopAdminPoll();
+        this._stopAdminWritePoll();
         if (this._metricsChart) {
             this._metricsChart.destroy();
             this._metricsChart = null;
@@ -110,6 +125,7 @@ class NodeDrawer {
 
         body.innerHTML = '';
         body.appendChild(this._buildActions(n));
+        body.appendChild(this._buildRemoteConfigSection(n));
         body.appendChild(this._buildMetricsChartSection(n));
         body.appendChild(this._buildInfoSection(n));
         body.appendChild(this._buildSignalSection(n));
@@ -143,6 +159,424 @@ class NodeDrawer {
         }
 
         return div;
+    }
+
+    _buildRemoteConfigSection(n) {
+        const section = document.createElement('div');
+        section.className = 'nd-section nd-section--remote-config';
+
+        const header = document.createElement('div');
+        header.className = 'nd-section__header';
+        header.innerHTML = `<span class="nd-section__title">Remote Configuration</span>
+            <span class="nd-section__arrow">\u25BC</span>`;
+
+        const content = document.createElement('div');
+        content.className = 'nd-section__content nd-remote-config';
+
+        if (!this._adminConfigAvailable) {
+            content.innerHTML = `<p class="nd-remote-config__hint">Set <code>meshtastic.admin_key_b64</code> in local.yaml to enable ADMIN config read.</p>`;
+        } else {
+            const toolbar = document.createElement('div');
+            toolbar.className = 'nd-remote-config__toolbar';
+
+            const select = document.createElement('select');
+            select.className = 'nd-remote-config__select';
+            select.setAttribute('aria-label', 'Config section');
+            [
+                ['device', 'Device'],
+                ['owner', 'Owner'],
+                ['lora', 'LoRa'],
+                ['position', 'Position'],
+            ].forEach(([value, label]) => {
+                const opt = document.createElement('option');
+                opt.value = value;
+                opt.textContent = label;
+                select.appendChild(opt);
+            });
+            toolbar.appendChild(select);
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'nd-action-btn nd-remote-config__btn';
+            btn.textContent = 'Request Config';
+            btn.addEventListener('click', () => {
+                this._requestRemoteConfig(n.node_id, select.value, btn, statusEl, resultEl);
+            });
+            toolbar.appendChild(btn);
+            content.appendChild(toolbar);
+
+            const statusEl = document.createElement('p');
+            statusEl.className = 'nd-remote-config__status';
+            statusEl.textContent = 'No request yet.';
+            content.appendChild(statusEl);
+
+            const resultEl = document.createElement('div');
+            resultEl.className = 'nd-remote-config__result';
+            content.appendChild(resultEl);
+
+            this._refreshRemoteConfigPanel(n.node_id, btn, statusEl, resultEl);
+            content.appendChild(this._buildRemoteConfigWriteForm(n));
+        }
+
+        header.addEventListener('click', () => {
+            const visible = content.style.display !== 'none';
+            content.style.display = visible ? 'none' : '';
+            header.querySelector('.nd-section__arrow').textContent = visible ? '\u25B6' : '\u25BC';
+        });
+
+        section.appendChild(header);
+        section.appendChild(content);
+        return section;
+    }
+
+    async _requestRemoteConfig(nodeId, section, btn, statusEl, resultEl) {
+        const now = Date.now();
+        if (now < this._adminConfigDebounceUntil) {
+            const left = Math.ceil((this._adminConfigDebounceUntil - now) / 1000);
+            statusEl.textContent = `Wait ${left}s before another request.`;
+            return;
+        }
+
+        btn.disabled = true;
+        statusEl.textContent = 'Sending ADMIN request…';
+        resultEl.innerHTML = '';
+
+        try {
+            const res = await fetch(
+                `/api/admin/nodes/${encodeURIComponent(nodeId)}/config/request`,
+                {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ section }),
+                },
+            );
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                statusEl.textContent = body.detail || `Request failed (${res.status})`;
+                if (res.status === 429) {
+                    this._adminConfigDebounceUntil = Date.now() + this._adminDebounceSeconds * 1000;
+                }
+                return;
+            }
+            this._adminConfigDebounceUntil = Date.now() + this._adminDebounceSeconds * 1000;
+            statusEl.textContent = 'Waiting for response (up to 30s)…';
+            this._startAdminPoll(nodeId, btn, statusEl, resultEl);
+        } catch (err) {
+            statusEl.textContent = 'Network error requesting config.';
+        } finally {
+            btn.disabled = Date.now() < this._adminConfigDebounceUntil;
+        }
+    }
+
+    _startAdminPoll(nodeId, btn, statusEl, resultEl) {
+        this._stopAdminPoll();
+        const started = Date.now();
+        const poll = async () => {
+            const data = await this._fetchRemoteConfigStatus(nodeId);
+            if (!data) return;
+
+            if (data.status === 'pending') {
+                const elapsed = Math.floor((Date.now() - started) / 1000);
+                statusEl.textContent = `Waiting for response… ${elapsed}s`;
+                return;
+            }
+
+            this._stopAdminPoll();
+            btn.disabled = Date.now() < this._adminConfigDebounceUntil;
+
+            if (data.status === 'complete') {
+                statusEl.textContent = `Received ${data.section || ''} config.`;
+                resultEl.innerHTML = this._formatRemoteConfigResult(data.config);
+            } else if (data.status === 'timeout') {
+                statusEl.innerHTML = 'No response within 30s. '
+                    + '<button type="button" class="nd-remote-config__retry">Retry</button>';
+                const retry = statusEl.querySelector('.nd-remote-config__retry');
+                if (retry) {
+                    retry.addEventListener('click', () => {
+                        const select = this._drawer.querySelector('.nd-remote-config__select');
+                        const section = select ? select.value : 'device';
+                        this._requestRemoteConfig(nodeId, section, btn, statusEl, resultEl);
+                    });
+                }
+            } else {
+                statusEl.textContent = data.error || `Status: ${data.status}`;
+            }
+        };
+        this._adminPollTimer = setInterval(poll, 2000);
+        poll();
+    }
+
+    _stopAdminPoll() {
+        if (this._adminPollTimer) {
+            clearInterval(this._adminPollTimer);
+            this._adminPollTimer = null;
+        }
+    }
+
+    async _refreshRemoteConfigPanel(nodeId, btn, statusEl, resultEl) {
+        const data = await this._fetchRemoteConfigStatus(nodeId);
+        if (!data || data.status === 'idle') return;
+        if (data.status === 'pending') {
+            statusEl.textContent = 'Request in progress…';
+            this._startAdminPoll(nodeId, btn, statusEl, resultEl);
+            return;
+        }
+        if (data.status === 'complete' && data.config) {
+            statusEl.textContent = `Last read: ${data.section || ''}`;
+            resultEl.innerHTML = this._formatRemoteConfigResult(data.config);
+        } else if (data.error) {
+            statusEl.textContent = data.error;
+        }
+    }
+
+    _formatRemoteConfigResult(config) {
+        if (!config) return '';
+        const rows = this._flattenConfigRows(config, '');
+        if (rows.length === 0) {
+            return '<p class="nd-remote-config__hint">Empty response.</p>';
+        }
+        return rows.map(([k, v]) => (
+            `<div class="nd-row"><span class="nd-row__label">${this._esc(k)}</span>`
+            + `<span class="nd-row__value">${this._esc(String(v))}</span></div>`
+        )).join('');
+    }
+
+    _flattenConfigRows(obj, prefix) {
+        const rows = [];
+        if (obj == null || typeof obj !== 'object') {
+            return rows;
+        }
+        Object.entries(obj).forEach(([key, value]) => {
+            const path = prefix ? `${prefix}.${key}` : key;
+            if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+                rows.push(...this._flattenConfigRows(value, path));
+            } else if (Array.isArray(value)) {
+                rows.push([path, value.join(', ')]);
+            } else if (value !== '' && value != null) {
+                rows.push([path, value]);
+            }
+        });
+        return rows;
+    }
+
+    async _fetchAdminConfigStatus() {
+        try {
+            const res = await fetch('/api/admin/remote-config/status', { credentials: 'same-origin' });
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
+    }
+
+    _buildRemoteConfigWriteForm(n) {
+        const form = document.createElement('div');
+        form.className = 'nd-remote-config__write';
+
+        const title = document.createElement('p');
+        title.className = 'nd-remote-config__write-title';
+        title.textContent = 'Apply changes (limited fields)';
+        form.appendChild(title);
+
+        const fields = [
+            { key: 'long_name', label: 'Long name', type: 'text', max: 40 },
+            { key: 'short_name', label: 'Short name', type: 'text', max: 4 },
+            {
+                key: 'role',
+                label: 'Device role',
+                type: 'select',
+                options: [
+                    ['', '— leave unchanged —'],
+                    ['0', 'CLIENT'],
+                    ['2', 'ROUTER'],
+                    ['3', 'ROUTER_CLIENT'],
+                    ['4', 'REPEATER'],
+                    ['5', 'TRACKER'],
+                    ['6', 'SENSOR'],
+                ],
+            },
+            { key: 'screen_on_secs', label: 'Screen timeout (s)', type: 'number', min: 0, max: 600 },
+            { key: 'telemetry_interval_secs', label: 'Telemetry interval (s)', type: 'number', min: 30, max: 86400 },
+        ];
+
+        const inputs = {};
+        fields.forEach((field) => {
+            const row = document.createElement('label');
+            row.className = 'nd-remote-config__field';
+            row.textContent = field.label;
+            let input;
+            if (field.type === 'select') {
+                input = document.createElement('select');
+                field.options.forEach(([value, label]) => {
+                    const opt = document.createElement('option');
+                    opt.value = value;
+                    opt.textContent = label;
+                    input.appendChild(opt);
+                });
+            } else {
+                input = document.createElement('input');
+                input.type = field.type;
+                if (field.max != null) input.maxLength = field.max;
+                if (field.min != null) input.min = String(field.min);
+                if (field.max != null && field.type === 'number') input.max = String(field.max);
+                input.placeholder = 'unchanged';
+            }
+            input.className = 'nd-remote-config__input';
+            input.dataset.writeKey = field.key;
+            row.appendChild(input);
+            form.appendChild(row);
+            inputs[field.key] = input;
+        });
+
+        const writeStatus = document.createElement('p');
+        writeStatus.className = 'nd-remote-config__status';
+        form.appendChild(writeStatus);
+
+        const writeBtn = document.createElement('button');
+        writeBtn.type = 'button';
+        writeBtn.className = 'nd-action-btn nd-action-btn--primary nd-remote-config__write-btn';
+        writeBtn.textContent = 'Apply Changes';
+        writeBtn.addEventListener('click', () => {
+            this._submitRemoteConfigWrite(n.node_id, inputs, writeBtn, writeStatus);
+        });
+        form.appendChild(writeBtn);
+
+        this._refreshRemoteWritePanel(n.node_id, writeStatus);
+        return form;
+    }
+
+    async _submitRemoteConfigWrite(nodeId, inputs, btn, statusEl) {
+        const payload = {};
+        Object.entries(inputs).forEach(([key, el]) => {
+            const raw = (el.value || '').trim();
+            if (!raw) return;
+            if (key === 'role') payload.role = parseInt(raw, 10);
+            else if (key === 'screen_on_secs' || key === 'telemetry_interval_secs') {
+                payload[key] = parseInt(raw, 10);
+            } else {
+                payload[key] = raw;
+            }
+        });
+
+        if (Object.keys(payload).length === 0) {
+            statusEl.textContent = 'Enter at least one field to change.';
+            return;
+        }
+
+        if (payload.role != null) {
+            if (!this._dangerousModal) {
+                statusEl.textContent = 'Confirmation modal unavailable.';
+                return;
+            }
+            const roleLabel = inputs.role.selectedOptions[0]?.textContent || payload.role;
+            const ok = await this._dangerousModal.confirm({
+                label: 'Change device role',
+                description: `This sends an ADMIN write to change role to ${roleLabel}. Mesh behavior may change immediately.`,
+                typedPhrase: 'CONFIRM',
+            });
+            if (!ok) {
+                statusEl.textContent = 'Role change cancelled.';
+                return;
+            }
+            payload.role_confirm = 'CONFIRM';
+        }
+
+        btn.disabled = true;
+        statusEl.textContent = 'Sending ADMIN write…';
+
+        try {
+            const res = await fetch(
+                `/api/admin/nodes/${encodeURIComponent(nodeId)}/config/write`,
+                {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                },
+            );
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                statusEl.textContent = body.detail || `Write failed (${res.status})`;
+                return;
+            }
+            statusEl.textContent = 'Write sent — verifying…';
+            this._startAdminWritePoll(nodeId, statusEl);
+        } catch {
+            statusEl.textContent = 'Network error during write.';
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    _startAdminWritePoll(nodeId, statusEl) {
+        this._stopAdminWritePoll();
+        const poll = async () => {
+            const data = await this._fetchRemoteWriteStatus(nodeId);
+            if (!data) return;
+            if (data.status === 'verifying' || data.status === 'writing') {
+                statusEl.textContent = 'Verifying write (auto read-back)…';
+                return;
+            }
+            this._stopAdminWritePoll();
+            if (data.status === 'verified') {
+                statusEl.textContent = 'Write verified by follow-up read.';
+            } else if (data.status === 'verify_timeout') {
+                statusEl.textContent = data.error || 'Verify read timed out.';
+            } else if (data.status === 'failed') {
+                statusEl.textContent = data.error || 'Write failed.';
+            }
+        };
+        this._adminWritePollTimer = setInterval(poll, 2000);
+        poll();
+    }
+
+    _stopAdminWritePoll() {
+        if (this._adminWritePollTimer) {
+            clearInterval(this._adminWritePollTimer);
+            this._adminWritePollTimer = null;
+        }
+    }
+
+    async _refreshRemoteWritePanel(nodeId, statusEl) {
+        const data = await this._fetchRemoteWriteStatus(nodeId);
+        if (!data || data.status === 'idle') return;
+        if (data.status === 'verifying' || data.status === 'writing') {
+            statusEl.textContent = 'Write in progress…';
+            this._startAdminWritePoll(nodeId, statusEl);
+            return;
+        }
+        if (data.status === 'verified') {
+            statusEl.textContent = 'Last write verified.';
+        } else if (data.error) {
+            statusEl.textContent = data.error;
+        }
+    }
+
+    async _fetchRemoteWriteStatus(nodeId) {
+        try {
+            const res = await fetch(
+                `/api/admin/nodes/${encodeURIComponent(nodeId)}/config/write`,
+                { credentials: 'same-origin' },
+            );
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
+    }
+
+    async _fetchRemoteConfigStatus(nodeId) {
+        try {
+            const res = await fetch(
+                `/api/admin/nodes/${encodeURIComponent(nodeId)}/config`,
+                { credentials: 'same-origin' },
+            );
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
     }
 
     _buildInfoSection(n) {

--- a/frontend/js/terminal/dangerous_modal.js
+++ b/frontend/js/terminal/dangerous_modal.js
@@ -17,6 +17,9 @@ class DangerousModal {
         this._codeEl = null;
         this._confirmBtn = null;
         this._cancelBtn = null;
+        this._typedWrap = null;
+        this._typedInput = null;
+        this._typedToken = null;
         this._currentResolver = null;
     }
 
@@ -31,6 +34,10 @@ class DangerousModal {
                 <h3 class="danger-modal__title" data-danger-title>Confirm</h3>
                 <p class="danger-modal__desc" data-danger-desc></p>
                 <pre class="danger-modal__code" data-danger-code></pre>
+                <label class="danger-modal__typed" data-danger-typed-wrap hidden>
+                    <span data-danger-typed-label></span>
+                    <input type="text" class="danger-modal__typed-input" data-danger-typed-input autocomplete="off" spellcheck="false" />
+                </label>
                 <div class="danger-modal__actions">
                     <button type="button" class="terminal-button terminal-button--ghost" data-danger-cancel>Cancel</button>
                     <button type="button" class="terminal-button terminal-button--danger" data-danger-confirm>Confirm</button>
@@ -44,16 +51,20 @@ class DangerousModal {
         this._codeEl = root.querySelector('[data-danger-code]');
         this._confirmBtn = root.querySelector('[data-danger-confirm]');
         this._cancelBtn = root.querySelector('[data-danger-cancel]');
+        this._typedWrap = root.querySelector('[data-danger-typed-wrap]');
+        this._typedInput = root.querySelector('[data-danger-typed-input]');
+        this._typedLabel = root.querySelector('[data-danger-typed-label]');
         const backdrop = root.querySelector('[data-danger-backdrop]');
 
         this._confirmBtn.addEventListener('click', () => this._resolve(true));
+        this._typedInput.addEventListener('input', () => this._syncTypedConfirm());
         this._cancelBtn.addEventListener('click', () => this._resolve(false));
         backdrop.addEventListener('click', () => this._resolve(false));
         document.addEventListener('keydown', (event) => {
             if (!this._currentResolver) return;
             if (event.key === 'Escape') {
                 this._resolve(false);
-            } else if (event.key === 'Enter') {
+            } else if (event.key === 'Enter' && !this._confirmBtn.disabled) {
                 event.preventDefault();
                 this._resolve(true);
             }
@@ -64,16 +75,38 @@ class DangerousModal {
      * Returns a Promise that resolves to ``true`` when the user
      * clicks Confirm (or presses Enter), ``false`` otherwise.
      */
-    confirm({ label, command, description }) {
+    confirm({ label, command, description, typedPhrase }) {
         this._ensureMounted();
         const labelText = (label || '').trim() || 'Confirm';
         this._titleEl.textContent = `Confirm: ${labelText}`;
         this._descEl.textContent = description || 'This command can leave the host in a degraded state.';
         this._codeEl.textContent = command || '';
         this._codeEl.style.display = command ? '' : 'none';
+        this._typedToken = (typedPhrase || '').trim() || null;
+        if (this._typedToken) {
+            this._typedWrap.hidden = false;
+            this._typedLabel.textContent = `Type ${this._typedToken} to confirm:`;
+            this._typedInput.value = '';
+            this._confirmBtn.disabled = true;
+        } else {
+            this._typedWrap.hidden = true;
+            this._typedInput.value = '';
+            this._confirmBtn.disabled = false;
+        }
         this._show();
-        setTimeout(() => this._confirmBtn.focus(), 50);
+        setTimeout(() => {
+            if (this._typedToken) this._typedInput.focus();
+            else this._confirmBtn.focus();
+        }, 50);
         return new Promise((resolve) => { this._currentResolver = resolve; });
+    }
+
+    _syncTypedConfirm() {
+        if (!this._typedToken) {
+            this._confirmBtn.disabled = false;
+            return;
+        }
+        this._confirmBtn.disabled = this._typedInput.value.trim() !== this._typedToken;
     }
 
     _show() {
@@ -87,8 +120,13 @@ class DangerousModal {
     }
 
     _resolve(value) {
+        if (value && this._typedToken
+            && this._typedInput.value.trim() !== this._typedToken) {
+            return;
+        }
         const resolver = this._currentResolver;
         this._currentResolver = null;
+        this._typedToken = null;
         this._hide();
         if (resolver) resolver(value);
     }

--- a/src/admin/__init__.py
+++ b/src/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Remote Meshtastic ADMIN config read (PR 15)."""

--- a/src/admin/config_decode.py
+++ b/src/admin/config_decode.py
@@ -1,0 +1,29 @@
+"""Decode Meshtastic ADMIN responses into JSON-safe, redacted dicts."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
+
+_SENSITIVE_RE = re.compile(
+    r"(psk|private_key|public_key|admin_key|session_passkey|passkey|key)$",
+    re.IGNORECASE,
+)
+
+
+def message_to_redacted_dict(msg: Message) -> dict[str, Any]:
+    """Convert a protobuf message to a dict with secrets redacted."""
+    raw = MessageToDict(msg, preserving_proto_field_name=True)
+    return _redact_value(raw)
+
+
+def _redact_value(value: Any, key: str | None = None) -> Any:
+    if key and _SENSITIVE_RE.search(key):
+        return "***"
+    if isinstance(value, dict):
+        return {k: _redact_value(v, k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value

--- a/src/admin/pending_store.py
+++ b/src/admin/pending_store.py
@@ -1,0 +1,114 @@
+"""In-memory pending remote config read requests (one slot per node)."""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+RequestStatus = Literal["idle", "pending", "complete", "timeout", "error"]
+
+REQUEST_TIMEOUT_SECONDS = 30.0
+DEBOUNCE_SECONDS = 30.0
+
+
+@dataclass
+class ConfigReadState:
+    node_id: str
+    request_id: str = ""
+    section: str = "device"
+    status: RequestStatus = "idle"
+    requested_at: float = 0.0
+    completed_at: float = 0.0
+    packet_id: str = ""
+    config: dict[str, Any] | None = None
+    error: str = ""
+    expected_response: str = "get_config_response"
+
+
+class PendingConfigStore:
+    """Tracks pending/completed config reads keyed by normalized node ID."""
+
+    def __init__(self) -> None:
+        self._by_node: dict[str, ConfigReadState] = {}
+
+    def get(self, node_id: str) -> ConfigReadState | None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return None
+        self._maybe_timeout(state)
+        return state
+
+    def can_request(
+        self, node_id: str, *, skip_debounce: bool = False
+    ) -> tuple[bool, str]:
+        if skip_debounce:
+            state = self._by_node.get(node_id)
+            if state and state.status == "pending":
+                return False, "Request already in progress"
+            return True, ""
+        state = self._by_node.get(node_id)
+        if state is None:
+            return True, ""
+        self._maybe_timeout(state)
+        if state.status == "pending":
+            elapsed = time.time() - state.requested_at
+            if elapsed < DEBOUNCE_SECONDS:
+                remaining = int(DEBOUNCE_SECONDS - elapsed)
+                return False, f"Request in progress; retry in {remaining}s"
+        if state.status in ("pending", "complete", "timeout", "error"):
+            elapsed = time.time() - state.requested_at
+            if elapsed < DEBOUNCE_SECONDS:
+                remaining = int(DEBOUNCE_SECONDS - elapsed)
+                return False, f"Wait {remaining}s before another request"
+        return True, ""
+
+    def begin(
+        self,
+        node_id: str,
+        *,
+        section: str,
+        packet_id: str,
+        expected_response: str,
+    ) -> ConfigReadState:
+        state = ConfigReadState(
+            node_id=node_id,
+            request_id=uuid.uuid4().hex[:12],
+            section=section,
+            status="pending",
+            requested_at=time.time(),
+            packet_id=packet_id,
+            expected_response=expected_response,
+            config=None,
+            error="",
+        )
+        self._by_node[node_id] = state
+        return state
+
+    def complete(
+        self,
+        node_id: str,
+        config: dict[str, Any],
+    ) -> None:
+        state = self._by_node.get(node_id)
+        if state is None or state.status != "pending":
+            return
+        state.status = "complete"
+        state.completed_at = time.time()
+        state.config = config
+
+    def fail(self, node_id: str, error: str) -> None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return
+        state.status = "error"
+        state.completed_at = time.time()
+        state.error = error
+
+    def _maybe_timeout(self, state: ConfigReadState) -> None:
+        if state.status != "pending":
+            return
+        if time.time() - state.requested_at >= REQUEST_TIMEOUT_SECONDS:
+            state.status = "timeout"
+            state.completed_at = time.time()
+            state.error = "No response within 30 seconds"

--- a/src/admin/reader.py
+++ b/src/admin/reader.py
@@ -1,0 +1,338 @@
+"""Build ADMIN get-config requests and correlate inbound responses."""
+from __future__ import annotations
+
+import base64
+import logging
+import struct
+from typing import Any
+
+from meshtastic.protobuf import admin_pb2, mesh_pb2
+
+from src.admin.config_decode import message_to_redacted_dict
+from src.admin.pending_store import PendingConfigStore
+from src.decode.crypto_service import CryptoService
+from src.models.packet import Packet
+from src.relay.node_id import normalize_node_id, validate_node_ids
+from src.transmit.tx_service import SendResult, TxService
+
+logger = logging.getLogger(__name__)
+
+PORTNUM_ADMIN = 6
+MESHTASTIC_HEADER_SIZE = 16
+
+_SECTION_CONFIG_TYPE: dict[str, int] = {
+    "device": admin_pb2.AdminMessage.DEVICE_CONFIG,
+    "position": admin_pb2.AdminMessage.POSITION_CONFIG,
+    "power": admin_pb2.AdminMessage.POWER_CONFIG,
+    "network": admin_pb2.AdminMessage.NETWORK_CONFIG,
+    "display": admin_pb2.AdminMessage.DISPLAY_CONFIG,
+    "lora": admin_pb2.AdminMessage.LORA_CONFIG,
+    "bluetooth": admin_pb2.AdminMessage.BLUETOOTH_CONFIG,
+    "security": admin_pb2.AdminMessage.SECURITY_CONFIG,
+}
+
+_MODULE_CONFIG_TYPE: dict[str, int] = {
+    "telemetry": admin_pb2.AdminMessage.TELEMETRY_CONFIG,
+}
+
+
+class AdminConfigReader:
+    """Send ADMIN read requests and capture responses from the RX pipeline."""
+
+    def __init__(
+        self,
+        *,
+        tx_service: TxService | None,
+        crypto: CryptoService | None,
+        admin_key_b64: str = "",
+        admin_channel_name: str = "admin",
+        local_node_id: int = 0,
+    ) -> None:
+        self._tx = tx_service
+        self._crypto = crypto
+        self._admin_key_b64 = (admin_key_b64 or "").strip()
+        self._admin_channel_name = (admin_channel_name or "admin").strip() or "admin"
+        self._local_node_id = local_node_id
+        self._store = PendingConfigStore()
+        self._admin_key: bytes | None = None
+        self._refresh_admin_key()
+
+    @property
+    def available(self) -> bool:
+        return bool(self._admin_key_b64 and self._admin_key)
+
+    @property
+    def store(self) -> PendingConfigStore:
+        return self._store
+
+    def update_config(
+        self,
+        *,
+        admin_key_b64: str = "",
+        admin_channel_name: str = "admin",
+        local_node_id: int = 0,
+    ) -> None:
+        self._admin_key_b64 = (admin_key_b64 or "").strip()
+        self._admin_channel_name = (admin_channel_name or "admin").strip() or "admin"
+        self._local_node_id = local_node_id
+        self._refresh_admin_key()
+
+    def _refresh_admin_key(self) -> None:
+        if not self._admin_key_b64:
+            self._admin_key = None
+            return
+        try:
+            raw = base64.b64decode(self._admin_key_b64)
+            self._admin_key = CryptoService._expand_key(raw)
+        except Exception:
+            logger.warning("Invalid meshtastic.admin_key_b64", exc_info=True)
+            self._admin_key = None
+
+    async def send_admin_to_node(
+        self,
+        node_id: str,
+        admin_msg: admin_pb2.AdminMessage,
+    ) -> SendResult:
+        """Send a pre-built ADMIN message to a remote node."""
+        if not self.available:
+            raise AdminConfigError(
+                "Remote ADMIN unavailable — set meshtastic.admin_key_b64",
+                status_code=503,
+            )
+        if self._tx is None or not self._tx.meshtastic_enabled:
+            raise AdminConfigError(
+                "Meshtastic TX not available",
+                status_code=503,
+            )
+        normalized = validate_node_ids([node_id])[0]
+        dest_int = int(normalized, 16)
+        if dest_int in (0, 0xFFFFFFFF):
+            raise AdminConfigError("Invalid destination node", status_code=400)
+        result = await self._tx.send_admin_message(
+            admin_payload=admin_msg.SerializeToString(),
+            destination=dest_int,
+            admin_key=self._admin_key,
+            admin_channel_name=self._admin_channel_name,
+            want_ack=True,
+        )
+        if not result.success:
+            raise AdminConfigError(
+                result.error or "ADMIN TX failed",
+                status_code=502,
+            )
+        return result
+
+    async def request_config(
+        self,
+        node_id: str,
+        section: str = "device",
+        *,
+        skip_debounce: bool = False,
+    ) -> dict[str, Any]:
+        if not self.available:
+            raise AdminConfigError(
+                "Remote config read unavailable — set meshtastic.admin_key_b64 in local.yaml",
+                status_code=503,
+            )
+        if self._tx is None or not self._tx.meshtastic_enabled:
+            raise AdminConfigError(
+                "Meshtastic TX not available (transmit.enabled required)",
+                status_code=503,
+            )
+
+        normalized = validate_node_ids([node_id])[0]
+        section_key = (section or "device").strip().lower()
+        if (
+            section_key not in _SECTION_CONFIG_TYPE
+            and section_key not in _MODULE_CONFIG_TYPE
+            and section_key != "owner"
+        ):
+            raise AdminConfigError(
+                f"Unknown config section {section!r}",
+                status_code=400,
+            )
+
+        ok, reason = self._store.can_request(
+            normalized, skip_debounce=skip_debounce
+        )
+        if not ok:
+            raise AdminConfigError(reason, status_code=429)
+
+        dest_int = int(normalized, 16)
+        if dest_int in (0, 0xFFFFFFFF):
+            raise AdminConfigError(
+                "Cannot request config from broadcast node",
+                status_code=400,
+            )
+
+        admin_msg, expected = self._build_read_request(section_key)
+        result = await self._tx.send_admin_message(
+            admin_payload=admin_msg.SerializeToString(),
+            destination=dest_int,
+            admin_key=self._admin_key,
+            admin_channel_name=self._admin_channel_name,
+            want_ack=True,
+        )
+        if not result.success:
+            raise AdminConfigError(
+                result.error or "ADMIN TX failed",
+                status_code=502,
+            )
+
+        state = self._store.begin(
+            normalized,
+            section=section_key,
+            packet_id=result.packet_id,
+            expected_response=expected,
+        )
+        return self._state_payload(state)
+
+    def get_status(self, node_id: str) -> dict[str, Any]:
+        normalized = normalize_node_id(node_id)
+        state = self._store.get(normalized)
+        if state is None:
+            return {
+                "node_id": normalized,
+                "status": "idle",
+                "section": None,
+                "config": None,
+                "error": "",
+            }
+        return self._state_payload(state)
+
+    def try_consume_packet(self, packet: Packet) -> None:
+        if not self.available or self._crypto is None:
+            return
+        if packet.protocol.value != "meshtastic":
+            return
+
+        source = normalize_node_id(packet.source_id or "")
+        state = self._store.get(source)
+        if state is None or state.status != "pending":
+            return
+
+        raw = packet.raw_radio_packet
+        if not raw or len(raw) < MESHTASTIC_HEADER_SIZE:
+            return
+
+        header = self._parse_header(raw[:MESHTASTIC_HEADER_SIZE])
+        if header is None:
+            return
+
+        if self._local_node_id and header["dest_id"] not in (
+            self._local_node_id,
+            0xFFFFFFFF,
+        ):
+            return
+
+        encrypted = raw[MESHTASTIC_HEADER_SIZE:]
+        decrypted = self._crypto.decrypt_meshtastic(
+            encrypted,
+            header["packet_id"],
+            header["source_id"],
+            key=self._admin_key,
+        )
+        if decrypted is None:
+            return
+
+        data = mesh_pb2.Data()
+        try:
+            data.ParseFromString(decrypted)
+        except Exception:
+            return
+        if data.portnum != PORTNUM_ADMIN:
+            return
+
+        admin_msg = admin_pb2.AdminMessage()
+        try:
+            admin_msg.ParseFromString(data.payload)
+        except Exception:
+            return
+
+        payload = self._extract_response(admin_msg, state.expected_response)
+        if payload is None:
+            return
+
+        self._store.complete(source, payload)
+        logger.info(
+            "ADMIN config response from %s section=%s request_id=%s",
+            source,
+            state.section,
+            state.request_id,
+        )
+
+    @staticmethod
+    def _build_read_request(section: str) -> tuple[admin_pb2.AdminMessage, str]:
+        msg = admin_pb2.AdminMessage()
+        if section == "owner":
+            msg.get_owner_request = True
+            return msg, "get_owner_response"
+        if section in _MODULE_CONFIG_TYPE:
+            msg.get_module_config_request = _MODULE_CONFIG_TYPE[section]
+            return msg, "get_module_config_response"
+        msg.get_config_request = _SECTION_CONFIG_TYPE[section]
+        return msg, "get_config_response"
+
+    @staticmethod
+    def _extract_response(
+        admin_msg: admin_pb2.AdminMessage,
+        expected: str,
+    ) -> dict[str, Any] | None:
+        if expected == "get_owner_response":
+            if not admin_msg.HasField("get_owner_response"):
+                return None
+            return {
+                "section": "owner",
+                "owner": message_to_redacted_dict(admin_msg.get_owner_response),
+            }
+        if expected == "get_module_config_response":
+            if not admin_msg.HasField("get_module_config_response"):
+                return None
+            mod_dict = message_to_redacted_dict(
+                admin_msg.get_module_config_response
+            )
+            populated = {
+                k: v for k, v in mod_dict.items() if v is not None and v != {}
+            }
+            return {"section": "module", "config": populated}
+        if not admin_msg.HasField("get_config_response"):
+            return None
+        cfg_dict = message_to_redacted_dict(admin_msg.get_config_response)
+        populated = {
+            k: v for k, v in cfg_dict.items() if v is not None and v != {}
+        }
+        return {"section": "config", "config": populated}
+
+    @staticmethod
+    def _parse_header(header_bytes: bytes) -> dict[str, int] | None:
+        try:
+            dest_id, source_id, packet_id = struct.unpack_from(
+                "<III", header_bytes, 0
+            )
+            return {
+                "dest_id": dest_id,
+                "source_id": source_id,
+                "packet_id": packet_id,
+            }
+        except struct.error:
+            return None
+
+    @staticmethod
+    def _state_payload(state) -> dict[str, Any]:
+        return {
+            "node_id": state.node_id,
+            "request_id": state.request_id,
+            "status": state.status,
+            "section": state.section,
+            "packet_id": state.packet_id,
+            "requested_at": state.requested_at,
+            "completed_at": state.completed_at or None,
+            "config": state.config,
+            "error": state.error,
+        }
+
+
+class AdminConfigError(Exception):
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/src/admin/write_store.py
+++ b/src/admin/write_store.py
@@ -1,0 +1,104 @@
+"""In-memory state for remote config write + verify operations."""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+WriteStatus = Literal[
+    "idle",
+    "writing",
+    "verifying",
+    "verified",
+    "verify_timeout",
+    "failed",
+]
+
+WRITE_DEBOUNCE_SECONDS = 30.0
+
+
+@dataclass
+class WriteOperationState:
+    node_id: str
+    operation_id: str = ""
+    status: WriteStatus = "idle"
+    changes: dict[str, Any] = field(default_factory=dict)
+    packets_sent: list[str] = field(default_factory=list)
+    verify_sections: list[str] = field(default_factory=list)
+    verify_result: dict[str, Any] | None = None
+    error: str = ""
+    started_at: float = 0.0
+    completed_at: float = 0.0
+
+
+class WriteOperationStore:
+    def __init__(self) -> None:
+        self._by_node: dict[str, WriteOperationState] = {}
+
+    def get(self, node_id: str) -> WriteOperationState | None:
+        return self._by_node.get(node_id)
+
+    def can_write(self, node_id: str) -> tuple[bool, str]:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return True, ""
+        if state.status in ("writing", "verifying"):
+            return False, "Write or verify already in progress"
+        if state.started_at and time.time() - state.started_at < WRITE_DEBOUNCE_SECONDS:
+            remaining = int(WRITE_DEBOUNCE_SECONDS - (time.time() - state.started_at))
+            return False, f"Wait {remaining}s before another write"
+        return True, ""
+
+    def begin(
+        self,
+        node_id: str,
+        *,
+        changes: dict[str, Any],
+        verify_sections: list[str],
+    ) -> WriteOperationState:
+        state = WriteOperationState(
+            node_id=node_id,
+            operation_id=uuid.uuid4().hex[:12],
+            status="writing",
+            changes=changes,
+            verify_sections=list(verify_sections),
+            started_at=time.time(),
+        )
+        self._by_node[node_id] = state
+        return state
+
+    def mark_verifying(self, node_id: str, packets_sent: list[str]) -> None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return
+        state.packets_sent = list(packets_sent)
+        state.status = "verifying"
+
+    def complete_verified(
+        self,
+        node_id: str,
+        verify_result: dict[str, Any],
+    ) -> None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return
+        state.status = "verified"
+        state.verify_result = verify_result
+        state.completed_at = time.time()
+
+    def fail(self, node_id: str, error: str) -> None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return
+        state.status = "failed"
+        state.error = error
+        state.completed_at = time.time()
+
+    def verify_timeout(self, node_id: str) -> None:
+        state = self._by_node.get(node_id)
+        if state is None:
+            return
+        state.status = "verify_timeout"
+        state.error = "Verify read timed out after write"
+        state.completed_at = time.time()

--- a/src/admin/writer.py
+++ b/src/admin/writer.py
@@ -1,0 +1,281 @@
+"""Remote Meshtastic ADMIN config write (limited fields, PR 16)."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from meshtastic.protobuf import admin_pb2, config_pb2, module_config_pb2
+
+from src.admin.reader import AdminConfigError, AdminConfigReader
+from src.admin.write_store import WRITE_DEBOUNCE_SECONDS, WriteOperationStore
+from src.relay.node_id import validate_node_ids
+from src.transmit.tx_service import TxService
+
+logger = logging.getLogger(__name__)
+
+ROLE_CONFIRM_TOKEN = "CONFIRM"
+
+_ALLOWED_ROLES = {
+    config_pb2.Config.DeviceConfig.Role.CLIENT,
+    config_pb2.Config.DeviceConfig.Role.CLIENT_MUTE,
+    config_pb2.Config.DeviceConfig.Role.ROUTER,
+    config_pb2.Config.DeviceConfig.Role.ROUTER_CLIENT,
+    config_pb2.Config.DeviceConfig.Role.REPEATER,
+    config_pb2.Config.DeviceConfig.Role.TRACKER,
+    config_pb2.Config.DeviceConfig.Role.SENSOR,
+}
+
+_VERIFY_POLL_INTERVAL = 2.0
+_VERIFY_TIMEOUT = 30.0
+_POST_WRITE_DELAY = 2.0
+
+
+class AdminConfigWriter:
+    """Apply a small allow-listed set of remote config changes via ADMIN TX."""
+
+    def __init__(
+        self,
+        *,
+        reader: AdminConfigReader,
+        tx_service: TxService | None,
+        write_store: WriteOperationStore | None = None,
+    ) -> None:
+        self._reader = reader
+        self._tx = tx_service
+        self._writes = write_store or WriteOperationStore()
+
+    @property
+    def store(self) -> WriteOperationStore:
+        return self._writes
+
+    def get_status(self, node_id: str) -> dict[str, Any]:
+        from src.relay.node_id import normalize_node_id
+
+        normalized = normalize_node_id(node_id)
+        state = self._writes.get(normalized)
+        if state is None or state.status == "idle":
+            return {
+                "node_id": normalized,
+                "status": "idle",
+                "operation_id": "",
+                "changes": None,
+                "verify_result": None,
+                "error": "",
+                "debounce_seconds": WRITE_DEBOUNCE_SECONDS,
+            }
+        return {
+            "node_id": state.node_id,
+            "operation_id": state.operation_id,
+            "status": state.status,
+            "changes": state.changes,
+            "packets_sent": state.packets_sent,
+            "verify_sections": state.verify_sections,
+            "verify_result": state.verify_result,
+            "error": state.error,
+            "started_at": state.started_at,
+            "completed_at": state.completed_at or None,
+            "debounce_seconds": WRITE_DEBOUNCE_SECONDS,
+        }
+
+    async def apply_changes(
+        self,
+        node_id: str,
+        *,
+        long_name: str | None = None,
+        short_name: str | None = None,
+        role: int | None = None,
+        role_confirm: str | None = None,
+        screen_on_secs: int | None = None,
+        telemetry_interval_secs: int | None = None,
+    ) -> dict[str, Any]:
+        self._ensure_available()
+        normalized = validate_node_ids([node_id])[0]
+        dest_int = int(normalized, 16)
+        if dest_int in (0, 0xFFFFFFFF):
+            raise AdminConfigError(
+                "Cannot write config to broadcast node",
+                status_code=400,
+            )
+
+        changes, verify_sections, messages = self._validate_and_build_messages(
+            long_name=long_name,
+            short_name=short_name,
+            role=role,
+            role_confirm=role_confirm,
+            screen_on_secs=screen_on_secs,
+            telemetry_interval_secs=telemetry_interval_secs,
+        )
+
+        ok, reason = self._writes.can_write(normalized)
+        if not ok:
+            raise AdminConfigError(reason, status_code=429)
+
+        state = self._writes.begin(
+            normalized,
+            changes=changes,
+            verify_sections=verify_sections,
+        )
+
+        packet_ids: list[str] = []
+        try:
+            for label, admin_msg in messages:
+                result = await self._reader.send_admin_to_node(
+                    normalized, admin_msg
+                )
+                packet_ids.append(result.packet_id)
+                logger.info(
+                    "ADMIN write %s to %s packet_id=%s",
+                    label,
+                    normalized,
+                    result.packet_id,
+                )
+
+            self._writes.mark_verifying(normalized, packet_ids)
+            asyncio.create_task(
+                self._verify_after_write(normalized, verify_sections)
+            )
+            return self.get_status(normalized)
+        except AdminConfigError:
+            self._writes.fail(normalized, "ADMIN write failed")
+            raise
+        except Exception as exc:
+            self._writes.fail(normalized, str(exc))
+            raise AdminConfigError(str(exc), status_code=502) from exc
+
+    async def _verify_after_write(
+        self,
+        node_id: str,
+        sections: list[str],
+    ) -> None:
+        await asyncio.sleep(_POST_WRITE_DELAY)
+        combined: dict[str, Any] = {}
+        try:
+            for section in sections:
+                await self._reader.request_config(
+                    node_id, section=section, skip_debounce=True
+                )
+                deadline = time.monotonic() + _VERIFY_TIMEOUT
+                while time.monotonic() < deadline:
+                    status = self._reader.get_status(node_id)
+                    if status["status"] == "complete":
+                        combined[section] = status.get("config")
+                        break
+                    if status["status"] in ("timeout", "error"):
+                        break
+                    await asyncio.sleep(_VERIFY_POLL_INTERVAL)
+                else:
+                    self._writes.verify_timeout(node_id)
+                    return
+            self._writes.complete_verified(node_id, combined)
+        except Exception as exc:
+            logger.exception("Verify after write failed for %s", node_id)
+            self._writes.fail(node_id, f"Verify failed: {exc}")
+
+    def _ensure_available(self) -> None:
+        if not self._reader.available:
+            raise AdminConfigError(
+                "Remote config write unavailable — set meshtastic.admin_key_b64",
+                status_code=503,
+            )
+        if self._tx is None or not self._tx.meshtastic_enabled:
+            raise AdminConfigError(
+                "Meshtastic TX not available (transmit.enabled required)",
+                status_code=503,
+            )
+
+    def _validate_and_build_messages(
+        self,
+        *,
+        long_name: str | None,
+        short_name: str | None,
+        role: int | None,
+        role_confirm: str | None,
+        screen_on_secs: int | None,
+        telemetry_interval_secs: int | None,
+    ) -> tuple[dict[str, Any], list[str], list[tuple[str, admin_pb2.AdminMessage]]]:
+        changes: dict[str, Any] = {}
+        verify_sections: list[str] = []
+        messages: list[tuple[str, admin_pb2.AdminMessage]] = []
+
+        if long_name is not None:
+            name = long_name.strip()
+            if not name or len(name) > 40:
+                raise AdminConfigError(
+                    "long_name must be 1–40 characters",
+                    status_code=400,
+                )
+            changes["long_name"] = name
+
+        if short_name is not None:
+            short = short_name.strip()
+            if not short or len(short) > 4:
+                raise AdminConfigError(
+                    "short_name must be 1–4 characters",
+                    status_code=400,
+                )
+            changes["short_name"] = short
+
+        if long_name is not None or short_name is not None:
+            msg = admin_pb2.AdminMessage()
+            if long_name is not None:
+                msg.set_owner.long_name = changes["long_name"]
+            if short_name is not None:
+                msg.set_owner.short_name = changes["short_name"]
+            messages.append(("owner", msg))
+            verify_sections.append("owner")
+
+        if role is not None:
+            if (role_confirm or "").strip() != ROLE_CONFIRM_TOKEN:
+                raise AdminConfigError(
+                    f'role change requires role_confirm="{ROLE_CONFIRM_TOKEN}"',
+                    status_code=400,
+                )
+            if role not in _ALLOWED_ROLES:
+                raise AdminConfigError(
+                    f"role {role} is not allowed for remote write",
+                    status_code=400,
+                )
+            changes["role"] = role
+            msg = admin_pb2.AdminMessage()
+            msg.set_config.device.role = role
+            messages.append(("device_role", msg))
+            if "device" not in verify_sections:
+                verify_sections.append("device")
+
+        if screen_on_secs is not None:
+            if not 0 <= screen_on_secs <= 600:
+                raise AdminConfigError(
+                    "screen_on_secs must be between 0 and 600",
+                    status_code=400,
+                )
+            changes["screen_on_secs"] = screen_on_secs
+            msg = admin_pb2.AdminMessage()
+            msg.set_config.display.screen_on_secs = screen_on_secs
+            messages.append(("display", msg))
+            if "display" not in verify_sections:
+                verify_sections.append("display")
+
+        if telemetry_interval_secs is not None:
+            if not 30 <= telemetry_interval_secs <= 86400:
+                raise AdminConfigError(
+                    "telemetry_interval_secs must be between 30 and 86400",
+                    status_code=400,
+                )
+            changes["telemetry_interval_secs"] = telemetry_interval_secs
+            msg = admin_pb2.AdminMessage()
+            msg.set_module_config.telemetry.device_update_interval = (
+                telemetry_interval_secs
+            )
+            messages.append(("telemetry", msg))
+            if "telemetry" not in verify_sections:
+                verify_sections.append("telemetry")
+
+        if not messages:
+            raise AdminConfigError(
+                "No writable fields provided",
+                status_code=400,
+            )
+
+        return changes, verify_sections, messages

--- a/src/api/routes/admin_routes.py
+++ b/src/api/routes/admin_routes.py
@@ -1,0 +1,185 @@
+"""Remote Meshtastic ADMIN config read/write routes (PR 15–16)."""
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from src.admin.pending_store import DEBOUNCE_SECONDS, REQUEST_TIMEOUT_SECONDS
+from src.admin.reader import AdminConfigError, AdminConfigReader
+from src.admin.write_store import WRITE_DEBOUNCE_SECONDS
+from src.admin.writer import AdminConfigWriter
+from src.api.audit import AuditLogWriter
+from src.api.audit.dependencies import get_audit_writer
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+_reader: AdminConfigReader | None = None
+_writer: AdminConfigWriter | None = None
+
+
+def init_routes(
+    *,
+    reader: AdminConfigReader | None,
+    writer: AdminConfigWriter | None = None,
+) -> None:
+    global _reader, _writer
+    _reader = reader
+    _writer = writer
+
+
+def reset_routes() -> None:
+    global _reader, _writer
+    _reader = None
+    _writer = None
+
+
+class ConfigRequestBody(BaseModel):
+    section: Literal[
+        "device",
+        "owner",
+        "lora",
+        "position",
+        "power",
+        "network",
+        "display",
+        "bluetooth",
+        "security",
+    ] = Field(default="device")
+
+
+@router.get("/remote-config/status")
+async def remote_config_status():
+    """Whether remote ADMIN config read is configured (no secrets)."""
+    if _reader is None:
+        return {
+            "available": False,
+            "debounce_seconds": DEBOUNCE_SECONDS,
+            "timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+            "write_debounce_seconds": WRITE_DEBOUNCE_SECONDS,
+            "writable_fields": [
+                "long_name",
+                "short_name",
+                "role",
+                "screen_on_secs",
+                "telemetry_interval_secs",
+            ],
+        }
+    return {
+        "available": _reader.available,
+        "debounce_seconds": DEBOUNCE_SECONDS,
+        "timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+        "write_debounce_seconds": WRITE_DEBOUNCE_SECONDS,
+        "writable_fields": [
+            "long_name",
+            "short_name",
+            "role",
+            "screen_on_secs",
+            "telemetry_interval_secs",
+        ],
+    }
+
+
+@router.get("/nodes/{node_id}/config")
+async def get_remote_config(node_id: str):
+    """Poll status/result for the latest config read on a node."""
+    if _reader is None:
+        raise HTTPException(503, "Remote config reader not initialized")
+    return _reader.get_status(node_id)
+
+
+@router.post("/nodes/{node_id}/config/request")
+async def request_remote_config(
+    node_id: str,
+    body: ConfigRequestBody | None = None,
+    section: str | None = Query(default=None),
+    claims: SessionClaims = Depends(require_admin),
+    audit: AuditLogWriter = Depends(get_audit_writer),
+):
+    """Send one ADMIN get-config request to a remote node (read-only)."""
+    if _reader is None:
+        raise HTTPException(503, "Remote config reader not initialized")
+
+    chosen = (body.section if body else None) or section or "device"
+    params = {
+        "target_node_id": node_id.strip().lower().lstrip("!"),
+        "section": chosen,
+    }
+
+    with audit.timed_action(
+        user=claims.subject,
+        action="admin.config_request",
+        params=params,
+    ) as ctx:
+        try:
+            result = await _reader.request_config(node_id, section=chosen)
+            ctx.params["packet_id"] = result.get("packet_id", "")
+            ctx.params["request_id"] = result.get("request_id", "")
+            ctx.params["status"] = result.get("status", "pending")
+            return result
+        except AdminConfigError as exc:
+            raise HTTPException(exc.status_code, str(exc)) from exc
+
+
+class ConfigWriteBody(BaseModel):
+    long_name: str | None = Field(default=None, max_length=40)
+    short_name: str | None = Field(default=None, max_length=4)
+    role: int | None = Field(default=None, ge=0, le=11)
+    role_confirm: str | None = Field(default=None, max_length=16)
+    screen_on_secs: int | None = Field(default=None, ge=0, le=600)
+    telemetry_interval_secs: int | None = Field(default=None, ge=30, le=86400)
+
+
+@router.get("/nodes/{node_id}/config/write")
+async def get_remote_config_write_status(node_id: str):
+    """Poll status for the latest config write + verify on a node."""
+    if _writer is None:
+        raise HTTPException(503, "Remote config writer not initialized")
+    return _writer.get_status(node_id)
+
+
+@router.post("/nodes/{node_id}/config/write")
+async def write_remote_config(
+    node_id: str,
+    body: ConfigWriteBody,
+    claims: SessionClaims = Depends(require_admin),
+    audit: AuditLogWriter = Depends(get_audit_writer),
+):
+    """Apply allow-listed ADMIN config writes; auto-read verifies afterward."""
+    if _writer is None:
+        raise HTTPException(503, "Remote config writer not initialized")
+
+    params = {
+        "target_node_id": node_id.strip().lower().lstrip("!"),
+        "changes": body.model_dump(exclude_none=True, exclude={"role_confirm"}),
+    }
+    if body.role is not None:
+        params["role_change"] = True
+
+    with audit.timed_action(
+        user=claims.subject,
+        action="admin.config_write",
+        params=params,
+    ) as ctx:
+        try:
+            result = await _writer.apply_changes(
+                node_id,
+                long_name=body.long_name,
+                short_name=body.short_name,
+                role=body.role,
+                role_confirm=body.role_confirm,
+                screen_on_secs=body.screen_on_secs,
+                telemetry_interval_secs=body.telemetry_interval_secs,
+            )
+            ctx.params["operation_id"] = result.get("operation_id", "")
+            ctx.params["status"] = result.get("status", "")
+            ctx.params["verify_sections"] = result.get("verify_sections", [])
+            return result
+        except AdminConfigError as exc:
+            raise HTTPException(exc.status_code, str(exc)) from exc

--- a/src/api/routes/config_enrichment.py
+++ b/src/api/routes/config_enrichment.py
@@ -52,24 +52,51 @@ def enrich_config_payload(cfg: AppConfig, base: dict) -> dict:
         "burst_size": relay.burst_size,
         "min_relay_rssi": relay.min_relay_rssi,
         "max_relay_rssi": relay.max_relay_rssi,
+        "blocklist": list(relay.blocklist or []),
+        "priority_list": list(relay.priority_list or []),
+        "dedup_ttl_seconds": relay.dedup_ttl_seconds,
+        "channel_throttle_percent": dict(relay.channel_throttle_percent or {}),
+        "storm_guard": {
+            "enabled": relay.storm_guard.enabled,
+            "window_seconds": relay.storm_guard.window_seconds,
+            "identical_packet_threshold": relay.storm_guard.identical_packet_threshold,
+            "rate_threshold_per_minute": relay.storm_guard.rate_threshold_per_minute,
+            "quarantine_duration_seconds": relay.storm_guard.quarantine_duration_seconds,
+            "notify_dashboard": relay.storm_guard.notify_dashboard,
+        },
     }
     base["radio_advanced"] = {
         "spectral_scan_interval_seconds": radio.spectral_scan_interval_seconds,
         "sx1261_spi_path": radio.sx1261_spi_path or "",
+        "carrier_type": radio.carrier_type or "",
+        "gps_pps_enabled": radio.gps_pps_enabled,
+        "gps_pps_tty_path": radio.gps_pps_tty_path,
+        "gps_family": radio.gps_family,
+        "gps_pps_target_baud": radio.gps_pps_target_baud,
     }
     base["location"] = {
         "source": location.source,
         "gpsd_host": location.gpsd_host,
         "gpsd_port": location.gpsd_port,
+        "uart_path": location.uart_path,
+        "uart_baud": location.uart_baud,
         "update_interval_seconds": location.update_interval_seconds,
         "min_fix_quality": location.min_fix_quality,
     }
-    pos = cfg.transmit.position
-    if "transmit" in base:
-        base["transmit"]["position"] = {
-            "interval_minutes": pos.interval_minutes,
-            "startup_delay_seconds": pos.startup_delay_seconds,
-            "coordinate_source": pos.coordinate_source,
-            "location_precision": pos.location_precision,
-        }
+    sh = cfg.signal_health
+    base["signal_health"] = {
+        "green_rssi_floor": sh.green_rssi_floor,
+        "yellow_rssi_floor": sh.yellow_rssi_floor,
+        "min_packets_per_hour": sh.min_packets_per_hour,
+    }
+    auto = cfg.automation
+    base["automation"] = {
+        "enabled": auto.enabled,
+        "token_set": bool((auto.token or "").strip()),
+    }
+    mt = cfg.meshtastic
+    base["meshtastic_admin"] = {
+        "config_read_available": bool((mt.admin_key_b64 or "").strip()),
+        "channel_name": (mt.admin_channel_name or "admin").strip() or "admin",
+    }
     return base

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -16,7 +16,11 @@ from src.api.audit import AuditLogWriter
 from src.api.audit import dependencies as audit_deps
 from src.api.auth import dependencies as auth_deps
 from src.api.auth.auth_bootstrap import AuthSubsystem, build_auth_subsystem
-from src.api.auth.dependencies import SESSION_COOKIE_NAME, require_auth
+from src.api.auth.dependencies import (
+    SESSION_COOKIE_NAME,
+    init_automation,
+    require_auth,
+)
 from src.api.auth.jwt_session import JwtSessionService
 from src.api.auth.ws_guard import WS_AUTH_CLOSE_CODE, authenticate_websocket
 from src.api.dangerous import DangerousActionRegistry
@@ -33,14 +37,20 @@ from src.api.meshcore_contacts import (
     setup_meshcore_contact_enrichment,
     sync_meshcore_contacts_to_nodes,
 )
+from src.admin.reader import AdminConfigReader
+from src.admin.writer import AdminConfigWriter
 from src.api.routes import (
+    admin_routes,
     analytics,
+    automation_routes,
     auth_config_routes,
     auth_routes,
     config_routes,
     dangerous_routes,
     device,
     device_config_routes,
+    firmware_routes,
+    gps_pps_status,
     gps_status,
     identity_routes,
     messages,
@@ -50,7 +60,12 @@ from src.api.routes import (
     nodes,
     packets,
     public_radar_routes,
+    relay_routes,
+    rf_routes,
+    metrics_routes,
     stats_routes,
+    stray_frames_routes,
+    webhooks_routes,
     system_config_routes,
     system_metrics,
     telemetry,
@@ -63,6 +78,7 @@ from src.api.terminal import CommandCatalog, SessionManager
 from src.api.update import ReleaseChannelRegistry, UpdateApplier
 from src.api.update.rollback_state import resolve_rollback_state_path
 from src.api.upstream_client import UpstreamClient
+from src.api.alert_emitter import AlertEmitter
 from src.api.websocket_manager import WebSocketManager
 from src.config import AppConfig, load_config, validate_activation
 from src.coordinator import PipelineCoordinator
@@ -76,9 +92,6 @@ from src.transmit.nodeinfo_broadcaster import (
     NodeInfoBroadcaster,
     clamp_interval_minutes,
 )
-from src.transmit.position_broadcaster import PositionBroadcaster
-from src.transmit.telemetry_broadcaster import TelemetryBroadcaster
-from src.transmit.meshtastic_inbound_handler import MeshtasticInboundHandler
 from src.transmit.tx_service import TxService
 from src.version import __version__
 
@@ -89,11 +102,11 @@ ws_manager = WebSocketManager()
 pipeline: PipelineCoordinator | None = None
 upstream: UpstreamClient | None = None
 nodeinfo_broadcaster: NodeInfoBroadcaster | None = None
-telemetry_broadcaster: TelemetryBroadcaster | None = None
-position_broadcaster: PositionBroadcaster | None = None
 noise_floor_tracker = NoiseFloorTracker()
 _noise_floor_emitter_task = None
 _spectral_scan_service: SpectralScanService | None = None
+_alert_emitter: AlertEmitter | None = None
+_webhook_engine = None
 
 
 def create_app(config: AppConfig | None = None) -> FastAPI:
@@ -104,6 +117,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     auth_routes.init_routes(auth_subsystem.service)
     auth_config_routes.init_routes(auth_subsystem.service)
     auth_deps.init_auth(auth_subsystem.jwt_service)
+    init_automation(config.automation)
     audit_writer = AuditLogWriter()
     audit_deps.init_audit(audit_writer)
     session_manager = SessionManager(cwd="/opt/meshpoint")
@@ -131,7 +145,6 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         global pipeline, upstream, nodeinfo_broadcaster
-        global telemetry_broadcaster, position_broadcaster
         warn_if_stale_so_files()
         validate_activation(config)
         identity = DeviceIdentity(
@@ -150,11 +163,19 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         pipeline.on_packet(lambda pkt: print_packet(pkt))
         pipeline.on_packet(public_radar_routes.public_radar_packet_callback)
 
+        # Mirror live GPS fixes from the location source into DeviceIdentity
+        # so /api/device (the local map) and the upstream registration
+        # payload (Meshradar fleet view) both see fresh coordinates.
+        def _sync_identity_position(lat, lon, alt):
+            identity.latitude = lat
+            identity.longitude = lon
+            if alt is not None:
+                identity.altitude = alt
+
+        pipeline.on_location_update(_sync_identity_position)
+
         if config.transmit.enabled:
             _inject_tx_gain_into_source(pipeline)
-
-        _bootstrap_pki(config, pipeline)
-        await _hydrate_public_keys(pipeline)
 
         await pipeline.start()
 
@@ -170,9 +191,8 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
                     _send_meshcore_advert(meshcore_tx_ref, mc_source)
                 )
         _setup_message_interception(
-            pipeline, message_repo, config, meshcore_tx_ref, tx_service
+            pipeline, message_repo, config, meshcore_tx_ref
         )
-        _setup_inbound_responder(pipeline, tx_service, config)
         setup_meshcore_contact_enrichment(pipeline, meshcore_tx_ref)
         if meshcore_tx_ref and meshcore_tx_ref.connected:
             import asyncio
@@ -195,25 +215,41 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         if nodeinfo_broadcaster is not None:
             await nodeinfo_broadcaster.start()
 
-        telemetry_broadcaster = _build_telemetry_broadcaster(
-            config, tx_service, pipeline
-        )
-        if telemetry_broadcaster is not None:
-            await telemetry_broadcaster.start()
-
-        position_broadcaster = _build_position_broadcaster(
-            config, tx_service, pipeline
-        )
-        if position_broadcaster is not None:
-            await position_broadcaster.start()
-
         _wire_native_relay(pipeline, tx_service)
 
-        global _noise_floor_emitter_task
+        global _noise_floor_emitter_task, _alert_emitter, _webhook_engine
         import asyncio
         _noise_floor_emitter_task = asyncio.get_running_loop().create_task(
             _noise_floor_emitter_loop(noise_floor_tracker, ws_manager)
         )
+        _alert_emitter = AlertEmitter(pipeline.node_repo, ws_manager)
+        await _alert_emitter.start()
+
+        from src.webhook.engine import WebhookEngine
+
+        _webhook_engine = WebhookEngine(
+            config.webhooks,
+            config.device.device_name,
+            pipeline.node_repo,
+            pipeline.relay_manager,
+            audit_writer,
+        )
+        pipeline.on_packet(_webhook_engine.on_packet)
+        await _webhook_engine.start()
+
+        storm_guard = pipeline.relay_manager.storm_guard
+        if storm_guard is not None:
+
+            def _on_storm_quarantine(entry) -> None:
+                if (
+                    config.relay.storm_guard.notify_dashboard
+                    and _alert_emitter is not None
+                ):
+                    _alert_emitter.on_storm_quarantine(entry)
+                if _webhook_engine is not None:
+                    _webhook_engine.on_storm_quarantine(entry)
+
+            storm_guard.set_on_quarantine(_on_storm_quarantine)
 
         global _spectral_scan_service
         _spectral_scan_service = _build_spectral_scan_service(
@@ -231,6 +267,10 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         yield
         if _spectral_scan_service is not None:
             await _spectral_scan_service.stop()
+        if _alert_emitter is not None:
+            await _alert_emitter.stop()
+        if _webhook_engine is not None:
+            await _webhook_engine.stop()
         if _noise_floor_emitter_task is not None:
             _noise_floor_emitter_task.cancel()
             try:
@@ -239,10 +279,6 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
                 pass
         if nodeinfo_broadcaster is not None:
             await nodeinfo_broadcaster.stop()
-        if telemetry_broadcaster is not None:
-            await telemetry_broadcaster.stop()
-        if position_broadcaster is not None:
-            await position_broadcaster.stop()
         await upstream.stop()
         await pipeline.stop()
         session_manager.shutdown()
@@ -255,16 +291,20 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     )
 
     app.include_router(auth_routes.router)
+    app.include_router(metrics_routes.router)
     app.include_router(identity_routes.router)
     app.include_router(auth_config_routes.router)
     app.include_router(public_radar_routes.router)
     app.include_router(terminal_routes.router)
+    app.include_router(firmware_routes.router)
     app.include_router(update_routes.router)
     app.include_router(dangerous_routes.router)
+    app.include_router(automation_routes.router)
 
     protected = [Depends(require_auth)]
     app.include_router(nodes.router, dependencies=protected)
     app.include_router(packets.router, dependencies=protected)
+    app.include_router(stray_frames_routes.router, dependencies=protected)
     app.include_router(analytics.router, dependencies=protected)
     app.include_router(device.router, dependencies=protected)
     app.include_router(system_metrics.router, dependencies=protected)
@@ -276,10 +316,15 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(upstream_config_routes.router, dependencies=protected)
     app.include_router(device_config_routes.router, dependencies=protected)
     app.include_router(gps_status.router, dependencies=protected)
+    app.include_router(gps_pps_status.router, dependencies=protected)
     app.include_router(system_config_routes.router, dependencies=protected)
     app.include_router(meshcore_config_routes.router, dependencies=protected)
     app.include_router(config_routes.router, dependencies=protected)
     app.include_router(stats_routes.router, dependencies=protected)
+    app.include_router(rf_routes.router, dependencies=protected)
+    app.include_router(webhooks_routes.router, dependencies=protected)
+    app.include_router(relay_routes.router, dependencies=protected)
+    app.include_router(admin_routes.router, dependencies=protected)
 
     @app.websocket("/ws")
     async def websocket_endpoint(websocket: WebSocket):
@@ -394,212 +439,6 @@ def _add_meshcore_usb_source(
         )
 
 
-def _resolve_mesh_node_id(config: AppConfig) -> int | None:
-    configured = config.transmit.node_id
-    if configured is not None:
-        return configured
-    device_id = (config.device.device_id or "").strip()
-    if not device_id:
-        return None
-    try:
-        return TxService._derive_node_id(device_id)
-    except RuntimeError:
-        return None
-
-
-def _bootstrap_pki(config: AppConfig, coord: PipelineCoordinator) -> None:
-    """Load PKI keypair and wire decoder identity before packet capture starts."""
-    from src.identity.keypair import (
-        KeypairStore,
-        resolve_keypair_path,
-        resolve_keypair_path_from_env,
-    )
-
-    if not hasattr(coord, "_crypto"):
-        return
-
-    coord._crypto.set_node_db_path(config.storage.database_path)
-    our_node_id = _resolve_mesh_node_id(config)
-    if our_node_id is not None:
-        coord._router.meshtastic_decoder.configure_identity(our_node_id)
-        logger.info(
-            "Meshtastic PKI identity configured: 0x%08x", our_node_id
-        )
-
-    override = resolve_keypair_path_from_env()
-    key_path = override or resolve_keypair_path(config.storage.database_path)
-    try:
-        keypair = KeypairStore(key_path).load_or_create()
-        coord._crypto.set_keypair(keypair.private_key, keypair.public_key)
-        logger.info("Meshtastic PKI keypair loaded from %s", key_path)
-    except Exception:
-        logger.exception("Failed to load Meshtastic PKI keypair")
-
-
-async def _hydrate_public_keys(coord: PipelineCoordinator) -> None:
-    if not hasattr(coord, "_crypto"):
-        return
-    await coord.database.connect()
-    rows = await coord.database.fetch_all(
-        """
-        SELECT node_id, public_key FROM nodes
-        WHERE public_key IS NOT NULL AND public_key != ''
-        LIMIT 5000
-        """
-    )
-    for row in rows:
-        node_id = row.get("node_id")
-        public_key = row.get("public_key")
-        if not node_id or not public_key:
-            continue
-        try:
-            coord._crypto.register_public_key(
-                int(node_id, 16),
-                bytes.fromhex(public_key),
-            )
-        except ValueError:
-            continue
-
-
-def _telemetry_metrics_providers(
-    tx_service: TxService,
-    coord: PipelineCoordinator,
-    service_started: float,
-    *,
-    noise_floor_tracker=None,
-    relay_manager=None,
-):
-    """Shared device_metrics / local_stats snapshots for TX paths."""
-    import time
-
-    duty = getattr(tx_service, "_duty", None)
-    stats = getattr(coord, "stats_reporter", None)
-
-    def device_metrics() -> dict:
-        air_util = duty.current_usage_percent() if duty else 0.0
-        return {
-            "battery_level": 101,
-            "voltage": 5.0,
-            "channel_utilization": 0.0,
-            "air_util_tx": round(air_util, 2),
-            "uptime_seconds": int(time.monotonic() - service_started),
-        }
-
-    def local_stats() -> dict:
-        dm = device_metrics()
-        noise_floor = None
-        if noise_floor_tracker is not None:
-            snap = noise_floor_tracker.snapshot()
-            value_dbm = snap.get("value_dbm")
-            if value_dbm is not None:
-                noise_floor = int(round(value_dbm))
-        relayed = 0
-        if relay_manager is not None:
-            relayed = int(relay_manager.get_stats().get("relayed", 0))
-        return {
-            "uptime_seconds": dm["uptime_seconds"],
-            "channel_utilization": dm["channel_utilization"],
-            "air_util_tx": dm["air_util_tx"],
-            "num_packets_tx": 0,
-            "num_packets_rx": stats.total_packets if stats else 0,
-            "num_packets_rx_bad": 0,
-            "num_online_nodes": 0,
-            "num_total_nodes": 0,
-            "num_tx_relay": relayed,
-            "noise_floor": noise_floor,
-        }
-
-    return device_metrics, local_stats
-
-
-def _setup_inbound_responder(
-    coord: PipelineCoordinator,
-    tx_service: TxService | None,
-    config: AppConfig,
-) -> None:
-    if tx_service is None or not tx_service.meshtastic_enabled:
-        return
-
-    import time
-
-    our_node_id = tx_service.source_node_id
-    our_node_hex = f"{our_node_id:08x}"
-    coord._router.meshtastic_decoder.configure_identity(our_node_id)
-    coord.relay_manager.set_local_node_id(our_node_hex)
-    device_fn, local_fn = _telemetry_metrics_providers(
-        tx_service,
-        coord,
-        time.monotonic(),
-        noise_floor_tracker=noise_floor_tracker,
-        relay_manager=coord.relay_manager,
-    )
-    tx_service.set_telemetry_reply_providers(device_fn, local_fn)
-    handler = MeshtasticInboundHandler(tx_service, our_node_id)
-
-    def on_packet(packet: Packet) -> None:
-        import asyncio
-
-        try:
-            asyncio.get_running_loop().create_task(handler.handle(packet))
-        except RuntimeError:
-            pass
-
-    coord.on_packet(on_packet)
-
-
-def _build_telemetry_broadcaster(
-    config: AppConfig,
-    tx_service: TxService | None,
-    coord: PipelineCoordinator,
-) -> TelemetryBroadcaster | None:
-    if tx_service is None or not tx_service.meshtastic_enabled:
-        return None
-    telem = config.transmit.telemetry
-    if clamp_interval_minutes(telem.interval_minutes) == 0:
-        return None
-
-    import time
-
-    service_started = time.monotonic()
-    device_fn, _local_fn = _telemetry_metrics_providers(
-        tx_service,
-        coord,
-        service_started,
-        noise_floor_tracker=noise_floor_tracker,
-        relay_manager=coord.relay_manager,
-    )
-
-    return TelemetryBroadcaster(
-        tx_service,
-        interval_minutes=telem.interval_minutes,
-        startup_delay_seconds=telem.startup_delay_seconds,
-        metrics_provider=device_fn,
-    )
-
-
-def _build_position_broadcaster(
-    config: AppConfig,
-    tx_service: TxService | None,
-    coord: PipelineCoordinator,
-) -> PositionBroadcaster | None:
-    if tx_service is None or not tx_service.meshtastic_enabled:
-        return None
-    pos_cfg = config.transmit.position
-    if clamp_interval_minutes(pos_cfg.interval_minutes) == 0:
-        return None
-
-    from src.transmit.mesh_position_resolver import MeshPositionResolver
-
-    resolver = MeshPositionResolver(config, coord.location_source)
-
-    return PositionBroadcaster(
-        tx_service,
-        interval_minutes=pos_cfg.interval_minutes,
-        startup_delay_seconds=pos_cfg.startup_delay_seconds,
-        coords_provider=resolver.resolve,
-    )
-
-
 def _build_tx_service(
     config: AppConfig, coord: PipelineCoordinator
 ) -> TxService | None:
@@ -690,7 +529,6 @@ def _wire_native_relay(
             )
 
     relay.set_transmit_function(_native_relay)
-    relay.set_local_node_id(f"{tx_service.source_node_id:08x}")
     logger.info(
         "Relay backend: native onboard SX1302 (identity-preserving)"
     )
@@ -925,7 +763,6 @@ def _setup_message_interception(
     message_repo: MessageRepository,
     config: AppConfig,
     meshcore_tx=None,
-    tx_service: TxService | None = None,
 ) -> None:
     """Register a callback to intercept TEXT messages for storage.
 
@@ -933,14 +770,9 @@ def _setup_message_interception(
     conversations. DMs between other nodes are tagged as 'overheard'.
     MeshCore DMs use destination_id='self' to indicate they're for us.
     """
-    from src.api.message_name_resolver import MessageNameResolver
     from src.models.packet import PacketType, Protocol
 
-    name_resolver = MessageNameResolver(coord.node_repo, meshcore_tx)
-
     our_node_id = config.transmit.node_id
-    if our_node_id is None and tx_service is not None:
-        our_node_id = tx_service.source_node_id
     our_node_hex = f"{our_node_id:08x}" if our_node_id else ""
 
     mc_name_cache: dict[str, str] = {}
@@ -1080,17 +912,19 @@ def _setup_message_interception(
             if (
                 packet.protocol == Protocol.MESHTASTIC
                 and direction == "received"
+                and not node_name
             ):
-                sender_lookup = (
-                    (packet.source_id or "")
-                    if is_broadcast
-                    else node_id
-                )
-                node_name = await name_resolver.resolve(
-                    sender_lookup,
-                    packet.protocol.value,
-                    node_name or packet.source_id or "",
-                )
+                src_id = (packet.source_id or "").lower()
+                if src_id:
+                    row = await coord.node_repo._db.fetch_one(
+                        "SELECT long_name, short_name FROM nodes "
+                        "WHERE LOWER(node_id) = ? AND protocol = 'meshtastic'",
+                        (src_id,),
+                    )
+                    if row:
+                        node_name = row["long_name"] or row["short_name"] or ""
+                    if not node_name:
+                        node_name = packet.source_id or ""
 
             if is_broadcast and packet.protocol == Protocol.MESHCORE:
                 node_name = (packet.decoded_payload or {}).get("long_name", "")
@@ -1170,20 +1004,10 @@ def _setup_message_interception(
                     "snr": round(row["snr"], 1) if row and row["snr"] else None,
                 })
             else:
-                ws_name_lookup = (
-                    (packet.source_id or "")
-                    if is_broadcast and packet.protocol == Protocol.MESHTASTIC
-                    else node_id
-                )
-                display_name = await name_resolver.resolve(
-                    ws_name_lookup,
-                    packet.protocol.value,
-                    node_name,
-                )
                 ws_payload = {
                     "text": text,
                     "node_id": node_id,
-                    "node_name": display_name,
+                    "node_name": node_name,
                     "protocol": packet.protocol.value,
                     "direction": direction,
                     "packet_id": packet.packet_id or "",
@@ -1224,6 +1048,7 @@ def _init_routes(
         telemetry_repo=coord.telemetry_repo,
     )
     packets.init_routes(coord.packet_repo)
+    stray_frames_routes.init_routes(coord.stray_repo)
     analytics.init_routes(signal_analyzer, traffic_monitor, coord.packet_repo)
     device.init_routes(identity, ws_manager, coord.relay_manager)
     telemetry.init_routes(coord.telemetry_repo)
@@ -1236,6 +1061,28 @@ def _init_routes(
         node_repo=coord.node_repo,
         packet_repo=coord.packet_repo,
     )
+    global _spectral_scan_service
+    rf_routes.init_routes(
+        noise_floor_tracker,
+        _spectral_scan_service,
+        config,
+    )
+    metrics_routes.init_routes(
+        metrics_config=config.metrics,
+        stats_reporter=coord.stats_reporter,
+        signal_analyzer=signal_analyzer,
+        traffic_monitor=traffic_monitor,
+        relay_manager=coord.relay_manager,
+        node_repo=coord.node_repo,
+        noise_floor_tracker=noise_floor_tracker,
+        capture_coordinator=coord.capture_coordinator,
+        region=config.radio.region or "US",
+    )
+    webhooks_routes.init_routes(_webhook_engine)
+    relay_routes.init_routes(
+        config=config,
+        relay_manager=coord.relay_manager,
+    )
 
     meshcore_tx = None
     if tx_service and hasattr(tx_service, '_meshcore_tx'):
@@ -1247,7 +1094,6 @@ def _init_routes(
         node_repo=coord.node_repo,
         meshcore_tx=meshcore_tx,
         config=config,
-        packet_repo=coord.packet_repo,
     )
 
     crypto = coord._crypto if hasattr(coord, "_crypto") else None
@@ -1265,8 +1111,61 @@ def _init_routes(
     upstream_config_routes.init_routes(config=config)
     device_config_routes.init_routes(config=config, identity=identity)
     gps_status.init_routes(location_source=coord.location_source)
-    system_config_routes.init_routes(config=config)
+    gps_pps_status.init_routes(
+        get_wrapper=lambda: _get_concentrator_wrapper(coord),
+    )
+    system_config_routes.init_routes(
+        config=config,
+        relay_manager=coord.relay_manager,
+    )
+
+    async def _suspend_meshcore_for_flash(port: str) -> None:
+        src = _find_meshcore_source(coord)
+        if src is None:
+            return
+        resolved = getattr(src, "_resolved_port", None) or port
+        configured = getattr(src, "_configured_port", None)
+        if resolved != port and configured != port:
+            logger.info(
+                "MeshCore USB port %s does not match active source %s — skip release",
+                port,
+                resolved,
+            )
+            return
+        await src.release_serial_for_flash()
+
+    mc_usb = config.capture.meshcore_usb
+    default_mc_port = (mc_usb.serial_port or "/dev/ttyUSB0").strip()
+    firmware_routes.init_routes(
+        jwt_service=auth_subsystem.jwt_service,
+        suspend_meshcore=_suspend_meshcore_for_flash,
+        default_serial_port=default_mc_port,
+    )
     meshcore_config_routes.init_routes(config=config, tx_service=tx_service)
+
+    local_node_id = 0
+    if tx_service is not None:
+        local_node_id = tx_service.source_node_id
+    elif config.transmit.node_id:
+        local_node_id = config.transmit.node_id
+
+    admin_reader = AdminConfigReader(
+        tx_service=tx_service,
+        crypto=crypto,
+        admin_key_b64=config.meshtastic.admin_key_b64,
+        admin_channel_name=config.meshtastic.admin_channel_name,
+        local_node_id=local_node_id,
+    )
+    admin_writer = AdminConfigWriter(
+        reader=admin_reader,
+        tx_service=tx_service,
+    )
+    admin_routes.init_routes(reader=admin_reader, writer=admin_writer)
+
+    def _on_admin_config_packet(packet: Packet) -> None:
+        admin_reader.try_consume_packet(packet)
+
+    coord.on_packet(_on_admin_config_packet)
 
 
 def _init_dangerous_registry(coord: PipelineCoordinator) -> None:
@@ -1405,6 +1304,8 @@ def _on_packet_received(packet: Packet) -> None:
             snr_db=packet.signal.snr,
             bandwidth_khz=packet.signal.bandwidth_khz,
         )
+    if _alert_emitter is not None:
+        _alert_emitter.on_packet(packet)
     try:
         loop = asyncio.get_running_loop()
         loop.create_task(ws_manager.broadcast("packet", packet.to_dict()))

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import logging
 import os
 import sys
 from dataclasses import dataclass, field
@@ -11,8 +10,6 @@ from typing import Optional
 import yaml
 
 from src.version import __version__
-
-logger = logging.getLogger(__name__)
 
 
 # Band-start frequencies (MHz) for the Meshtastic slot formula
@@ -60,14 +57,26 @@ class RadioConfig:
     # (default; spectral scan stays unavailable, packet-derived
     # noise floor remains in use).
     #
-    # On RAK2287 / RAK5146 / SenseCap M1 this is typically
-    # ``/dev/spidev0.1`` (separate from the SX1302's
-    # ``/dev/spidev0.0``). Some carriers daisy-chain the SX1261
-    # behind the SX1302's SPI router and want this set to the same
-    # path as the SX1302 SPI device. Wrong path = HAL refuses to
-    # ``lgw_start`` after our config attempt, so we ship empty by
-    # default and ask interested users to opt in explicitly.
+    # On RAK2287 / RAK5146 / SenseCap M1 the SX1261 is behind the
+    # concentrator's internal SPI router, not on a Pi chip-select —
+    # leave empty. Only the Semtech reference kit and custom carriers
+    # with a dedicated SX1261 CE line need a path (e.g.
+    # ``/dev/spidev0.1``). Wrong path can brick ``lgw_start`` on
+    # boards without Pi-visible SX1261; ``carrier_type`` guard clears
+    # mistaken values on RAK/SenseCap.
     sx1261_spi_path: str = ""
+    # Carrier board signature from setup wizard I2C probe (``rak``,
+    # ``sensecap_m1``, or empty). Used to block Pi-visible SX1261 SPI
+    # paths that brick ``lgw_start()`` on RAK/SenseCap concentrators.
+    carrier_type: str = ""
+    # HAL GPS/PPS: align concentrator packet timestamps with GPS time via
+    # libloragw ``lgw_gps_*`` + ``sx1302_gps_enable``. Requires a HAL build
+    # that includes loragw_gps.c. Exclusive with ``location.source: uart`` on
+    # the same TTY (only one process may open the GPS serial port).
+    gps_pps_enabled: bool = False
+    gps_pps_tty_path: str = "/dev/ttyAMA0"
+    gps_family: str = "ubx7"
+    gps_pps_target_baud: int = 0
 
 
 @dataclass
@@ -75,6 +84,9 @@ class MeshtasticConfig:
     default_key_b64: str = "AQ=="
     primary_channel_name: str = "LongFast"
     channel_keys: dict[str, str] = field(default_factory=dict)
+    # PSK for the shared "admin" channel — required for remote ADMIN config read.
+    admin_key_b64: str = ""
+    admin_channel_name: str = "admin"
 
 
 @dataclass
@@ -115,6 +127,45 @@ class StorageConfig:
 
 
 @dataclass
+class StrayFramesConfig:
+    """Undecodable RF frame logger (PR 08)."""
+
+    enabled: bool = True
+    max_retained: int = 10_000
+    retention_hours: float = 168.0
+
+
+@dataclass
+class MetricsConfig:
+    """Prometheus-compatible /metrics scrape endpoint (PR 09)."""
+
+    enabled: bool = False
+    require_auth: bool = True
+
+
+@dataclass
+class WebhookRuleConfig:
+    """One outbound HTTP rule for a mesh event (PR 10)."""
+
+    name: str = ""
+    url: str = ""
+    event: str = ""
+    enabled: bool = True
+    cooldown_seconds: float = 300.0
+    keyword: Optional[str] = None
+    battery_threshold_percent: float = 20.0
+    duty_threshold_percent: float = 80.0
+
+
+@dataclass
+class WebhookConfig:
+    """Event-driven outbound webhooks (PR 10)."""
+
+    enabled: bool = False
+    rules: list[WebhookRuleConfig] = field(default_factory=list)
+
+
+@dataclass
 class DashboardConfig:
     host: str = "0.0.0.0"  # nosec B104 -- intentional for local device dashboard
     port: int = 8080
@@ -142,6 +193,18 @@ class DeviceConfig:
 
 
 @dataclass
+class StormGuardConfig:
+    """Memory-only storm/replay quarantine (PR 12)."""
+
+    enabled: bool = False
+    window_seconds: int = 60
+    identical_packet_threshold: int = 5
+    rate_threshold_per_minute: int = 30
+    quarantine_duration_seconds: int = 300
+    notify_dashboard: bool = True
+
+
+@dataclass
 class RelayConfig:
     enabled: bool = False
     serial_port: Optional[str] = None
@@ -150,29 +213,11 @@ class RelayConfig:
     burst_size: int = 5
     min_relay_rssi: float = -110.0
     max_relay_rssi: float = -50.0
-
-
-@dataclass
-class TelemetryConfig:
-    """Periodic device_metrics telemetry broadcast settings."""
-
-    interval_minutes: int = 30
-    startup_delay_seconds: int = 120
-
-
-@dataclass
-class PositionConfig:
-    """Periodic POSITION broadcast settings."""
-
-    interval_minutes: int = 15
-    startup_delay_seconds: int = 180
-    # Coordinates sent on the public LoRa mesh (Meshtastic POSITION packets).
-    # ``static`` uses ``device.{latitude,longitude,altitude}`` (wizard pin).
-    # ``live`` reads the active ``LocationSource`` (gpsd/uart) when a fix exists.
-    coordinate_source: str = "static"
-    # Privacy when ``coordinate_source`` is ``live``: exact, approximate
-    # (~1.1 km rounding), or none (skip position on mesh). Ignored for static.
-    location_precision: str = "approximate"
+    blocklist: list[str] = field(default_factory=list)
+    priority_list: list[str] = field(default_factory=list)
+    dedup_ttl_seconds: int = 300
+    channel_throttle_percent: dict[str, float] = field(default_factory=dict)
+    storm_guard: StormGuardConfig = field(default_factory=StormGuardConfig)
 
 
 @dataclass
@@ -184,8 +229,6 @@ class MqttConfig:
     password: str = "large4cats"
     topic_root: str = "msh"
     region: str = "US"
-    tls_enabled: bool = False
-    tls_ca_cert: str = ""
     # Optional ``!xxxxxxxx`` override; blank uses MD5 hash of device name.
     gateway_id: Optional[str] = None
     publish_channels: list[str] = field(default_factory=lambda: ["LongFast", "MeshCore"])
@@ -230,8 +273,6 @@ class TransmitConfig:
     short_name: str = "MPNT"
     hop_limit: int = 3
     nodeinfo: NodeInfoConfig = field(default_factory=NodeInfoConfig)
-    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
-    position: PositionConfig = field(default_factory=PositionConfig)
 
 
 @dataclass
@@ -241,15 +282,12 @@ class LocationConfig:
     ``source`` values:
         - ``"static"``   : use ``device.latitude/longitude/altitude`` from
                            ``local.yaml``. Backward-compatible default.
-        - ``"gpsd"``     : connect to a local or remote ``gpsd`` daemon for
-                           live fixes (skyplot, optional mesh POSITION).
-                           Does not change ``device.{lat,lon,alt}`` (Meshradar
-                           pin). Auto-installed by ``scripts/install.sh``.
-        - ``"uart"``     : reserved for direct on-board UART NMEA reading
-                           (RAK Pi HAT GPS). Plumbing exists in
-                           ``src.hal.gps_reader`` but is not wired into
-                           the runtime yet; treated as ``static`` until
-                           the source is implemented.
+        - ``"gpsd"``     : connect to a local or remote ``gpsd`` daemon and
+                           overwrite ``device.{lat,lon,alt}`` when fixes
+                           arrive. Auto-installed by ``scripts/install.sh``.
+        - ``"uart"``     : read NMEA GGA from an on-board UART GPS (RAK Pi
+                           HAT on ``/dev/ttyAMA0``). Uses
+                           ``src.hal.gps_reader.GpsReader``.
 
     ``gpsd_host`` / ``gpsd_port`` default to gpsd's well-known
     localhost socket. Override only when running gpsd on a peer
@@ -269,6 +307,8 @@ class LocationConfig:
     source: str = "static"
     gpsd_host: str = "127.0.0.1"
     gpsd_port: int = 2947
+    uart_path: str = "/dev/ttyAMA0"
+    uart_baud: int = 9600
     update_interval_seconds: int = 5
     min_fix_quality: int = 1
 
@@ -305,6 +345,23 @@ class WebAuthConfig:
 
 
 @dataclass
+class SignalHealthConfig:
+    """Thresholds for node-card RSSI health badges and sparklines."""
+
+    green_rssi_floor: float = -100
+    yellow_rssi_floor: float = -115
+    min_packets_per_hour: int = 5
+
+
+@dataclass
+class ApiAutomationConfig:
+    """LAN automation API for Home Assistant / Node-RED scripting."""
+
+    enabled: bool = False
+    token: str = ""
+
+
+@dataclass
 class AppConfig:
     radio: RadioConfig = field(default_factory=RadioConfig)
     meshtastic: MeshtasticConfig = field(default_factory=MeshtasticConfig)
@@ -319,6 +376,11 @@ class AppConfig:
     transmit: TransmitConfig = field(default_factory=TransmitConfig)
     web_auth: WebAuthConfig = field(default_factory=WebAuthConfig)
     location: LocationConfig = field(default_factory=LocationConfig)
+    signal_health: SignalHealthConfig = field(default_factory=SignalHealthConfig)
+    automation: ApiAutomationConfig = field(default_factory=ApiAutomationConfig)
+    stray_frames: StrayFramesConfig = field(default_factory=StrayFramesConfig)
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    webhooks: WebhookConfig = field(default_factory=WebhookConfig)
 
 
 def _resolve_radio_frequency(radio: "RadioConfig") -> None:
@@ -356,25 +418,6 @@ def _merge_dataclass(instance, overrides: dict):
             setattr(instance, key, value)
 
 
-def _collect_unknown_keys(instance, overrides: dict, prefix: str = "") -> list[str]:
-    """Return dotted paths of override keys with no matching dataclass field.
-
-    Mirrors the descent rules in :func:`_merge_dataclass`: it only recurses
-    into a nested dataclass (e.g. ``transmit.nodeinfo``), so user-supplied
-    mapping fields such as ``meshtastic.channel_keys`` are treated as opaque
-    values rather than scanned for "unknown" keys.
-    """
-    unknown: list[str] = []
-    for key, value in overrides.items():
-        if not hasattr(instance, key):
-            unknown.append(f"{prefix}{key}")
-            continue
-        current = getattr(instance, key)
-        if dataclasses.is_dataclass(current) and isinstance(value, dict):
-            unknown.extend(_collect_unknown_keys(current, value, f"{prefix}{key}."))
-    return unknown
-
-
 def _apply_yaml(cfg: AppConfig, path: Path) -> None:
     """Merge a single YAML file into an existing AppConfig."""
     if not path.exists():
@@ -382,10 +425,6 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
 
     with open(path, "r") as fh:
         raw = yaml.safe_load(fh) or {}
-
-    if not isinstance(raw, dict):
-        logger.warning("Ignoring %s: top-level YAML is not a mapping.", path)
-        return
 
     section_map = {
         "radio": cfg.radio,
@@ -401,28 +440,16 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
         "transmit": cfg.transmit,
         "web_auth": cfg.web_auth,
         "location": cfg.location,
+        "signal_health": cfg.signal_health,
+        "automation": cfg.automation,
+        "stray_frames": cfg.stray_frames,
+        "metrics": cfg.metrics,
+        "webhooks": cfg.webhooks,
     }
 
-    unknown_keys: list[str] = []
-    for section_name, section_value in raw.items():
-        section_instance = section_map.get(section_name)
-        if section_instance is None:
-            unknown_keys.append(section_name)
-            continue
-        _merge_dataclass(section_instance, section_value)
-        if isinstance(section_value, dict):
-            unknown_keys.extend(
-                _collect_unknown_keys(section_instance, section_value, f"{section_name}.")
-            )
-
-    if unknown_keys:
-        logger.warning(
-            "Ignoring %d unknown config key(s) in %s: %s. "
-            "These were not applied -- check for typos against the documented schema.",
-            len(unknown_keys),
-            path,
-            ", ".join(sorted(unknown_keys)),
-        )
+    for section_name, section_instance in section_map.items():
+        if section_name in raw:
+            _merge_dataclass(section_instance, raw[section_name])
 
 
 _VALID_CONFIG_EXTENSIONS = {".yaml", ".yml"}
@@ -449,8 +476,90 @@ def load_config(config_path: Optional[str] = None) -> AppConfig:
     local = config_path or os.environ.get("CONCENTRATOR_CONFIG", "config/local.yaml")
     _apply_yaml(cfg, _validated_config_path(local))
     _resolve_radio_frequency(cfg.radio)
+    _normalize_webhook_rules(cfg.webhooks)
+    validate_config_consistency(cfg)
+    validate_webhook_config(cfg.webhooks)
 
     return cfg
+
+
+def _normalize_webhook_rules(webhooks: WebhookConfig) -> None:
+    """Convert YAML dict rules into WebhookRuleConfig instances."""
+    normalized: list[WebhookRuleConfig] = []
+    for item in webhooks.rules:
+        if isinstance(item, WebhookRuleConfig):
+            normalized.append(item)
+        elif isinstance(item, dict):
+            normalized.append(WebhookRuleConfig(**item))
+    webhooks.rules = normalized
+
+
+def validate_webhook_config(webhooks: WebhookConfig) -> None:
+    """Reject invalid webhook rules at startup."""
+    if not webhooks.enabled:
+        return
+
+    if not webhooks.rules:
+        raise ValueError(
+            "webhooks.enabled is true but webhooks.rules is empty"
+        )
+
+    seen_names: set[str] = set()
+    for rule in webhooks.rules:
+        name = (rule.name or "").strip()
+        if not name:
+            raise ValueError("each webhooks.rules entry requires a name")
+        if name in seen_names:
+            raise ValueError(f"duplicate webhook rule name: {name!r}")
+        seen_names.add(name)
+
+        event = (rule.event or "").strip().lower()
+        if event not in {
+            "battery_low",
+            "node_offline",
+            "node_online",
+            "keyword_match",
+            "duty_spike",
+            "storm_quarantine",
+        }:
+            raise ValueError(
+                f"webhook rule {name!r} has unknown event {rule.event!r}"
+            )
+
+        url = (rule.url or "").strip()
+        if not url:
+            raise ValueError(f"webhook rule {name!r} requires a url")
+        if not (url.startswith("http://") or url.startswith("https://")):
+            raise ValueError(
+                f"webhook rule {name!r} url must start with http:// or https://"
+            )
+
+        if rule.cooldown_seconds < 0:
+            raise ValueError(
+                f"webhook rule {name!r} cooldown_seconds must be >= 0"
+            )
+
+        if event == "keyword_match" and not (rule.keyword or "").strip():
+            raise ValueError(
+                f"webhook rule {name!r} (keyword_match) requires keyword"
+            )
+
+
+def validate_config_consistency(config: AppConfig) -> None:
+    """Reject impossible radio/location combinations before hardware starts."""
+    if not config.radio.gps_pps_enabled:
+        return
+    if config.location.source != "uart":
+        return
+    pps_tty = os.path.normpath(config.radio.gps_pps_tty_path)
+    uart_tty = os.path.normpath(config.location.uart_path)
+    if pps_tty == uart_tty:
+        raise ValueError(
+            "radio.gps_pps_enabled and location.source=uart cannot share "
+            f"the same serial device ({pps_tty!r}). Use location.source=gpsd "
+            "or static for dashboard coordinates while PPS owns the HAT UART, "
+            "or disable gps_pps_enabled when using UART for location only."
+        )
 
 
 def _get_local_yaml_path() -> Path:

--- a/src/relay/node_id.py
+++ b/src/relay/node_id.py
@@ -1,0 +1,28 @@
+"""Normalize and validate Meshtastic node IDs for relay filter lists."""
+
+from __future__ import annotations
+
+import re
+
+_NODE_ID_RE = re.compile(r"^[0-9a-f]{8}$", re.IGNORECASE)
+
+
+def normalize_node_id(node_id: str) -> str:
+    """Strip optional ``!`` prefix and lowercase for consistent matching."""
+    return (node_id or "").strip().lower().lstrip("!")
+
+
+def validate_node_ids(node_ids: list[str]) -> list[str]:
+    """Return normalized unique node IDs or raise ValueError."""
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for raw in node_ids:
+        nid = normalize_node_id(raw)
+        if not _NODE_ID_RE.match(nid):
+            raise ValueError(
+                f"Invalid node ID {raw!r} — expected 8 hex chars (no ! prefix)"
+            )
+        if nid not in seen:
+            seen.add(nid)
+            normalized.append(nid)
+    return normalized

--- a/src/transmit/meshtastic_builder.py
+++ b/src/transmit/meshtastic_builder.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import struct
-from typing import Sequence
 
 from src.decode.crypto_service import CryptoService
 
@@ -17,13 +16,9 @@ logger = logging.getLogger(__name__)
 
 BROADCAST_ADDR = 0xFFFFFFFF
 PORTNUM_TEXT_MESSAGE = 1
-PORTNUM_POSITION = 3
 PORTNUM_NODEINFO = 4
-PORTNUM_ROUTING = 5
-PORTNUM_TELEMETRY = 67
-PORTNUM_TRACEROUTE = 70
+PORTNUM_ADMIN = 6
 HW_MODEL_PRIVATE_HW = 255
-MAINS_BATTERY_LEVEL = 101
 
 
 class MeshtasticPacketBuilder:
@@ -43,32 +38,26 @@ class MeshtasticPacketBuilder:
         hop_limit: int = 3,
         hop_start: int = 3,
         want_ack: bool = False,
-        recipient_public_key: bytes | None = None,
     ) -> bytes | None:
-        """Build a complete encrypted TEXT_MESSAGE_APP packet."""
+        """Build a complete encrypted TEXT_MESSAGE_APP packet.
+
+        Returns the full on-air byte sequence (header + ciphertext),
+        or None if encryption fails.
+        """
         inner = self._serialize_data(PORTNUM_TEXT_MESSAGE, text.encode("utf-8"))
-        ciphertext = self._encrypt_payload(
-            inner,
-            packet_id,
-            source_id,
-            dest,
-            channel_key,
-            channel_hash,
-            recipient_public_key,
+        ciphertext = self._crypto.encrypt_meshtastic(
+            inner, packet_id, source_id, key=channel_key
         )
         if ciphertext is None:
             logger.error("Encryption failed for packet %d", packet_id)
             return None
 
-        on_air_hash = 0 if recipient_public_key else channel_hash
         header = self._build_header(
-            dest,
-            source_id,
-            packet_id,
+            dest, source_id, packet_id,
             hop_limit=hop_limit,
             hop_start=hop_start,
             want_ack=want_ack,
-            channel_hash=on_air_hash,
+            channel_hash=channel_hash,
         )
         return header + ciphertext
 
@@ -79,16 +68,20 @@ class MeshtasticPacketBuilder:
         long_name: str,
         short_name: str,
         hw_model: int = HW_MODEL_PRIVATE_HW,
-        public_key: bytes | None = None,
         channel_key: bytes | None = None,
         channel_hash: int = 0x08,
         hop_limit: int = 3,
         hop_start: int = 3,
     ) -> bytes | None:
-        """Build a broadcast NODEINFO_APP packet announcing this node."""
+        """Build a broadcast NODEINFO_APP packet announcing this node.
+
+        Wraps a serialized ``User`` protobuf in the standard encrypted
+        Meshtastic envelope. Recipients use this to populate their
+        contact list so DMs can be addressed by name.
+        """
         node_id_str = f"!{source_id:08x}"
         user_payload = self._serialize_user(
-            node_id_str, long_name, short_name, hw_model, public_key
+            node_id_str, long_name, short_name, hw_model
         )
         inner = self._serialize_data(PORTNUM_NODEINFO, user_payload)
         ciphertext = self._crypto.encrypt_meshtastic(
@@ -99,9 +92,7 @@ class MeshtasticPacketBuilder:
             return None
 
         header = self._build_header(
-            BROADCAST_ADDR,
-            source_id,
-            packet_id,
+            BROADCAST_ADDR, source_id, packet_id,
             hop_limit=hop_limit,
             hop_start=hop_start,
             want_ack=False,
@@ -109,316 +100,54 @@ class MeshtasticPacketBuilder:
         )
         return header + ciphertext
 
-    def build_routing_ack(
+    def build_admin_message(
         self,
-        source_id: int,
+        admin_payload: bytes,
         dest: int,
-        packet_id: int,
-        request_id: int,
-        channel_key: bytes | None = None,
-        channel_hash: int = 0x08,
-        hop_limit: int = 3,
-        hop_start: int = 3,
-        recipient_public_key: bytes | None = None,
-    ) -> bytes | None:
-        """Build a ROUTING ACK for an inbound direct message."""
-        routing_payload = b""
-        inner = self._serialize_data(
-            PORTNUM_ROUTING, routing_payload, request_id=request_id
-        )
-        ciphertext = self._encrypt_payload(
-            inner,
-            packet_id,
-            source_id,
-            dest,
-            channel_key,
-            channel_hash,
-            recipient_public_key,
-        )
-        if ciphertext is None:
-            return None
-        on_air_hash = 0 if recipient_public_key else channel_hash
-        header = self._build_header(
-            dest,
-            source_id,
-            packet_id,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            want_ack=False,
-            channel_hash=on_air_hash,
-        )
-        return header + ciphertext
-
-    def build_telemetry(
-        self,
         source_id: int,
         packet_id: int,
-        *,
-        battery_level: int = MAINS_BATTERY_LEVEL,
-        voltage: float = 5.0,
-        channel_utilization: float = 0.0,
-        air_util_tx: float = 0.0,
-        uptime_seconds: int = 0,
-        channel_key: bytes | None = None,
-        channel_hash: int = 0x08,
+        admin_key: bytes,
+        admin_channel_name: str = "admin",
         hop_limit: int = 3,
         hop_start: int = 3,
+        want_ack: bool = True,
     ) -> bytes | None:
-        """Build a broadcast TELEMETRY device_metrics packet."""
-        try:
-            from meshtastic.protobuf import telemetry_pb2
-
-            telem = telemetry_pb2.Telemetry()
-            telem.device_metrics.battery_level = battery_level
-            telem.device_metrics.voltage = voltage
-            telem.device_metrics.channel_utilization = channel_utilization
-            telem.device_metrics.air_util_tx = air_util_tx
-            telem.device_metrics.uptime_seconds = uptime_seconds
-            payload = telem.SerializeToString()
-        except Exception:
-            logger.exception("Telemetry protobuf build failed")
-            return None
-
-        inner = self._serialize_data(PORTNUM_TELEMETRY, payload)
+        """Build an encrypted ADMIN_APP packet using the admin channel PSK."""
+        inner = self._serialize_data(PORTNUM_ADMIN, admin_payload)
+        channel_hash = self._crypto.compute_channel_hash(
+            admin_channel_name, admin_key
+        )
         ciphertext = self._crypto.encrypt_meshtastic(
-            inner, packet_id, source_id, key=channel_key
+            inner, packet_id, source_id, key=admin_key
         )
         if ciphertext is None:
+            logger.error("Admin encryption failed for packet %d", packet_id)
             return None
+
         header = self._build_header(
-            BROADCAST_ADDR,
+            dest,
             source_id,
             packet_id,
             hop_limit=hop_limit,
             hop_start=hop_start,
+            want_ack=want_ack,
             channel_hash=channel_hash,
         )
         return header + ciphertext
-
-    def build_telemetry_reply(
-        self,
-        source_id: int,
-        dest: int,
-        packet_id: int,
-        request_id: int,
-        *,
-        variant: str = "device_metrics",
-        battery_level: int = MAINS_BATTERY_LEVEL,
-        voltage: float = 5.0,
-        channel_utilization: float = 0.0,
-        air_util_tx: float = 0.0,
-        uptime_seconds: int = 0,
-        num_packets_tx: int = 0,
-        num_packets_rx: int = 0,
-        num_packets_rx_bad: int = 0,
-        num_online_nodes: int = 0,
-        num_total_nodes: int = 0,
-        num_tx_relay: int = 0,
-        noise_floor: int | None = None,
-        telemetry_time: int = 0,
-        channel_key: bytes | None = None,
-        channel_hash: int = 0x08,
-        hop_limit: int = 3,
-        hop_start: int = 3,
-        recipient_public_key: bytes | None = None,
-    ) -> bytes | None:
-        """Build a unicast TELEMETRY reply to a telemetry request."""
-        try:
-            from meshtastic.protobuf import telemetry_pb2
-
-            telem = telemetry_pb2.Telemetry()
-            if telemetry_time:
-                telem.time = telemetry_time
-            if variant == "local_stats":
-                ls = telem.local_stats
-                ls.uptime_seconds = uptime_seconds
-                ls.channel_utilization = channel_utilization
-                ls.air_util_tx = air_util_tx
-                ls.num_packets_tx = num_packets_tx
-                ls.num_packets_rx = num_packets_rx
-                ls.num_packets_rx_bad = num_packets_rx_bad
-                ls.num_online_nodes = num_online_nodes
-                ls.num_total_nodes = num_total_nodes
-                ls.num_tx_relay = num_tx_relay
-                if noise_floor is not None:
-                    ls.noise_floor = noise_floor
-            else:
-                telem.device_metrics.battery_level = battery_level
-                telem.device_metrics.voltage = voltage
-                telem.device_metrics.channel_utilization = channel_utilization
-                telem.device_metrics.air_util_tx = air_util_tx
-                telem.device_metrics.uptime_seconds = uptime_seconds
-            payload = telem.SerializeToString()
-        except Exception:
-            logger.exception("Telemetry reply protobuf build failed")
-            return None
-
-        inner = self._serialize_data(
-            PORTNUM_TELEMETRY, payload, request_id=request_id
-        )
-        ciphertext = self._encrypt_payload(
-            inner,
-            packet_id,
-            source_id,
-            dest,
-            channel_key,
-            channel_hash,
-            recipient_public_key,
-        )
-        if ciphertext is None:
-            return None
-        on_air_hash = 0 if recipient_public_key else channel_hash
-        header = self._build_header(
-            dest,
-            source_id,
-            packet_id,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            channel_hash=on_air_hash,
-        )
-        return header + ciphertext
-
-    def build_position(
-        self,
-        source_id: int,
-        packet_id: int,
-        latitude: float,
-        longitude: float,
-        altitude: float | None = None,
-        channel_key: bytes | None = None,
-        channel_hash: int = 0x08,
-        hop_limit: int = 3,
-        hop_start: int = 3,
-    ) -> bytes | None:
-        """Build a broadcast POSITION packet."""
-        try:
-            from meshtastic.protobuf import mesh_pb2
-
-            pos = mesh_pb2.Position()
-            pos.latitude_i = int(latitude * 1e7)
-            pos.longitude_i = int(longitude * 1e7)
-            if altitude is not None:
-                pos.altitude = int(altitude)
-            payload = pos.SerializeToString()
-        except Exception:
-            logger.exception("Position protobuf build failed")
-            return None
-
-        inner = self._serialize_data(PORTNUM_POSITION, payload)
-        ciphertext = self._crypto.encrypt_meshtastic(
-            inner, packet_id, source_id, key=channel_key
-        )
-        if ciphertext is None:
-            return None
-        header = self._build_header(
-            BROADCAST_ADDR,
-            source_id,
-            packet_id,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            channel_hash=channel_hash,
-        )
-        return header + ciphertext
-
-    def build_traceroute_reply(
-        self,
-        source_id: int,
-        dest: int,
-        packet_id: int,
-        route_nodes: Sequence[int],
-        *,
-        request_id: int = 0,
-        snr_towards: Sequence[int] | None = None,
-        route_back: Sequence[int] | None = None,
-        snr_back: Sequence[int] | None = None,
-        channel_key: bytes | None = None,
-        channel_hash: int = 0x08,
-        hop_limit: int = 3,
-        hop_start: int = 3,
-        recipient_public_key: bytes | None = None,
-    ) -> bytes | None:
-        """Build a TRACEROUTE reply with a RouteDiscovery payload."""
-        try:
-            from meshtastic.protobuf import mesh_pb2
-
-            rd = mesh_pb2.RouteDiscovery()
-            for node in route_nodes:
-                rd.route.append(node)
-            if snr_towards:
-                rd.snr_towards.extend(snr_towards)
-            if route_back:
-                rd.route_back.extend(route_back)
-            if snr_back:
-                rd.snr_back.extend(snr_back)
-            payload = rd.SerializeToString()
-        except Exception:
-            logger.exception("Traceroute protobuf build failed")
-            return None
-
-        inner = self._serialize_data(
-            PORTNUM_TRACEROUTE, payload, request_id=request_id
-        )
-        ciphertext = self._encrypt_payload(
-            inner,
-            packet_id,
-            source_id,
-            dest,
-            channel_key,
-            channel_hash,
-            recipient_public_key,
-        )
-        if ciphertext is None:
-            return None
-        on_air_hash = 0 if recipient_public_key else channel_hash
-        header = self._build_header(
-            dest,
-            source_id,
-            packet_id,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            channel_hash=on_air_hash,
-        )
-        return header + ciphertext
-
-    def _encrypt_payload(
-        self,
-        inner: bytes,
-        packet_id: int,
-        source_id: int,
-        dest: int,
-        channel_key: bytes | None,
-        channel_hash: int,
-        recipient_public_key: bytes | None,
-    ) -> bytes | None:
-        if (
-            recipient_public_key
-            and dest != BROADCAST_ADDR
-            and self._crypto.has_pki()
-        ):
-            return self._crypto.encrypt_meshtastic_pki(
-                inner,
-                packet_id,
-                source_id,
-                recipient_public_key,
-            )
-        return self._crypto.encrypt_meshtastic(
-            inner, packet_id, source_id, key=channel_key
-        )
 
     @staticmethod
-    def _serialize_data(
-        portnum: int, payload: bytes, request_id: int = 0
-    ) -> bytes:
-        """Serialize a mesh_pb2.Data protobuf manually."""
+    def _serialize_data(portnum: int, payload: bytes) -> bytes:
+        """Serialize a mesh_pb2.Data protobuf manually.
+
+        Avoids importing the full protobuf library at runtime.
+        Wire format: field 1 (portnum) varint + field 2 (payload) bytes.
+        """
         result = bytearray()
         result.append(0x08)
         result.extend(_encode_varint(portnum))
         result.append(0x12)
         result.extend(_encode_varint(len(payload)))
         result.extend(payload)
-        if request_id:
-            result.append(0x35)
-            result.extend(struct.pack("<I", request_id & 0xFFFFFFFF))
         return bytes(result)
 
     @staticmethod
@@ -427,9 +156,15 @@ class MeshtasticPacketBuilder:
         long_name: str,
         short_name: str,
         hw_model: int,
-        public_key: bytes | None = None,
     ) -> bytes:
-        """Serialize a mesh_pb2.User protobuf manually."""
+        """Serialize a mesh_pb2.User protobuf manually.
+
+        Wire format used here: field 1 (id, string), field 2
+        (long_name, string), field 3 (short_name, string), and field 5
+        (hw_model, varint). The ``macaddr`` field (4) is intentionally
+        omitted since the Meshpoint has no canonical radio MAC and
+        clients tolerate its absence.
+        """
         result = bytearray()
         for tag, text in (
             (0x0A, node_id_str),
@@ -442,10 +177,6 @@ class MeshtasticPacketBuilder:
             result.extend(encoded)
         result.append(0x28)
         result.extend(_encode_varint(hw_model))
-        if public_key:
-            result.append(0x42)
-            result.extend(_encode_varint(len(public_key)))
-            result.extend(public_key)
         return bytes(result)
 
     @staticmethod

--- a/src/transmit/tx_service.py
+++ b/src/transmit/tx_service.py
@@ -17,7 +17,6 @@ from typing import Optional
 
 from src.models.packet import Protocol
 from src.transmit.duty_cycle import DutyCycleTracker
-from src.transmit.reply_hop_policy import MeshtasticReplyHopPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -88,8 +87,6 @@ class TxService:
         self._source_node_id = self._resolve_node_id()
         if persist_derived_node_id:
             self._persist_derived_node_id_if_needed()
-        self._device_metrics_provider = None
-        self._local_stats_provider = None
 
     @property
     def meshtastic_enabled(self) -> bool:
@@ -106,35 +103,6 @@ class TxService:
     @property
     def source_node_id(self) -> int:
         return self._source_node_id
-
-    def set_telemetry_reply_providers(
-        self,
-        device_metrics_provider=None,
-        local_stats_provider=None,
-    ) -> None:
-        self._device_metrics_provider = device_metrics_provider
-        self._local_stats_provider = local_stats_provider
-
-    @staticmethod
-    def _recipient_pubkey_for_reply(original, requester: int, crypto) -> bytes | None:
-        """Use PKI only when the inbound request was PKI-encrypted (ch=0x00)."""
-        if original.channel_hash != 0:
-            return None
-        if crypto is None:
-            return None
-        key = crypto.lookup_public_key(requester)
-        if key is None:
-            key = crypto.refresh_public_key_from_db(requester)
-        return key
-
-    @staticmethod
-    def _reply_hop_fields(original, configured_hop_limit: int) -> tuple[int, int]:
-        """Mirror firmware hop limits for want_response replies."""
-        return MeshtasticReplyHopPolicy.reply_hop_fields(
-            original.hop_limit,
-            original.hop_start,
-            configured_hop_limit,
-        )
 
     @property
     def node_id_source(self) -> str:
@@ -190,9 +158,6 @@ class TxService:
 
         packet_id = self._next_packet_id()
         channel_hash, channel_key = self._resolve_channel(0)
-        public_key = None
-        if self._crypto is not None:
-            public_key = self._crypto.public_key
 
         try:
             nodeinfo_hop_limit = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
@@ -202,7 +167,6 @@ class TxService:
                 long_name=long_name,
                 short_name=short_name,
                 hw_model=hw_model,
-                public_key=public_key,
                 channel_key=channel_key,
                 channel_hash=channel_hash,
                 hop_limit=nodeinfo_hop_limit,
@@ -287,9 +251,6 @@ class TxService:
         dest_int = self._resolve_destination(destination, Protocol.MESHTASTIC)
         packet_id = self._next_packet_id()
         channel_hash, channel_key = self._resolve_channel(channel)
-        recipient_pubkey = None
-        if dest_int != BROADCAST_ADDR_MT and self._crypto is not None:
-            recipient_pubkey = self._crypto.lookup_public_key(dest_int)
 
         hop_limit = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
         packet_bytes = builder.build_text_message(
@@ -302,7 +263,6 @@ class TxService:
             hop_limit=hop_limit,
             hop_start=hop_limit,
             want_ack=want_ack,
-            recipient_public_key=recipient_pubkey,
         )
         if packet_bytes is None:
             return SendResult(
@@ -368,285 +328,78 @@ class TxService:
             error=f"lgw_send returned {result_code}",
         )
 
-    async def send_routing_ack(self, original) -> SendResult:
-        """Reply with a Meshtastic routing ACK to an inbound DM."""
-        if not self.meshtastic_enabled:
-            return SendResult(success=False, protocol="meshtastic", error="TX unavailable")
-
-        builder = self._get_builder()
-        if builder is None or not hasattr(builder, "build_routing_ack"):
-            return SendResult(success=False, protocol="meshtastic", error="Builder unavailable")
-
-        try:
-            request_id = int(original.packet_id, 16)
-            dest = int(original.source_id, 16)
-        except ValueError:
-            return SendResult(success=False, protocol="meshtastic", error="Invalid packet ids")
-
-        packet_id = self._next_packet_id()
-        channel_hash = original.channel_hash
-        _, channel_key = self._resolve_channel_by_hash(channel_hash)
-        recipient_pubkey = self._recipient_pubkey_for_reply(
-            original, dest, self._crypto
-        )
-        if channel_hash == 0 and recipient_pubkey is None:
-            return SendResult(
-                success=False,
-                protocol="meshtastic",
-                error="No public_key for PKI routing ACK recipient",
-            )
-        configured = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
-        hop_limit, hop_start = self._reply_hop_fields(original, configured)
-
-        packet_bytes = builder.build_routing_ack(
-            source_id=self._source_node_id,
-            dest=dest,
-            packet_id=packet_id,
-            request_id=request_id,
-            channel_key=channel_key,
-            channel_hash=channel_hash,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            recipient_public_key=recipient_pubkey,
-        )
-        if packet_bytes is None:
-            return SendResult(success=False, protocol="meshtastic", error="ACK build failed")
-
-        return await self._send_built_packet(packet_bytes, packet_id, label="routing ACK")
-
-    async def send_traceroute_reply(self, original) -> SendResult:
-        """Reply to a traceroute probe addressed to this node."""
-        if not self.meshtastic_enabled:
-            return SendResult(success=False, protocol="meshtastic", error="TX unavailable")
-
-        builder = self._get_builder()
-        if builder is None or not hasattr(builder, "build_traceroute_reply"):
-            return SendResult(success=False, protocol="meshtastic", error="Builder unavailable")
-
-        try:
-            requester = int(original.source_id, 16)
-            request_id = int(original.packet_id, 16)
-        except ValueError:
-            return SendResult(success=False, protocol="meshtastic", error="Invalid source id")
-
-        rx_snr = (
-            float(original.signal.snr)
-            if original.signal and original.signal.snr is not None
-            else None
-        )
-        route_nodes, snr_towards, route_back, snr_back = (
-            self._build_traceroute_reply_data(original, rx_snr)
-        )
-
-        packet_id = self._next_packet_id()
-        channel_hash = original.channel_hash
-        _, channel_key = self._resolve_channel_by_hash(channel_hash)
-        recipient_pubkey = self._recipient_pubkey_for_reply(
-            original, requester, self._crypto
-        )
-        if channel_hash == 0 and recipient_pubkey is None:
-            return SendResult(
-                success=False,
-                protocol="meshtastic",
-                error="No public_key for PKI traceroute reply recipient",
-            )
-        configured = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
-        hop_limit, hop_start = self._reply_hop_fields(original, configured)
-
-        packet_bytes = builder.build_traceroute_reply(
-            source_id=self._source_node_id,
-            dest=requester,
-            packet_id=packet_id,
-            route_nodes=route_nodes,
-            request_id=request_id,
-            snr_towards=snr_towards or None,
-            route_back=route_back or None,
-            snr_back=snr_back or None,
-            channel_key=channel_key,
-            channel_hash=channel_hash,
-            hop_limit=hop_limit,
-            hop_start=hop_start,
-            recipient_public_key=recipient_pubkey,
-        )
-        if packet_bytes is None:
-            return SendResult(
-                success=False, protocol="meshtastic", error="Traceroute build failed"
-            )
-
-        return await self._send_built_packet(
-            packet_bytes, packet_id, label="traceroute reply"
-        )
-
-    async def send_telemetry(
+    async def send_admin_message(
         self,
-        *,
-        battery_level: int = 101,
-        voltage: float = 5.0,
-        channel_utilization: float = 0.0,
-        air_util_tx: float = 0.0,
-        uptime_seconds: int = 0,
+        admin_payload: bytes,
+        destination: int | str,
+        admin_key: bytes,
+        admin_channel_name: str = "admin",
+        want_ack: bool = True,
     ) -> SendResult:
+        """Transmit an ADMIN_APP packet encrypted with the admin channel PSK."""
         if not self.meshtastic_enabled:
-            return SendResult(success=False, protocol="meshtastic", error="TX unavailable")
-
-        builder = self._get_builder()
-        if builder is None or not hasattr(builder, "build_telemetry"):
-            return SendResult(success=False, protocol="meshtastic", error="Builder unavailable")
-
-        packet_id = self._next_packet_id()
-        channel_hash, channel_key = self._resolve_channel(0)
-        hop_limit = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
-
-        packet_bytes = builder.build_telemetry(
-            source_id=self._source_node_id,
-            packet_id=packet_id,
-            battery_level=battery_level,
-            voltage=voltage,
-            channel_utilization=channel_utilization,
-            air_util_tx=air_util_tx,
-            uptime_seconds=uptime_seconds,
-            channel_key=channel_key,
-            channel_hash=channel_hash,
-            hop_limit=hop_limit,
-            hop_start=hop_limit,
-        )
-        if packet_bytes is None:
-            return SendResult(success=False, protocol="meshtastic", error="Telemetry build failed")
-
-        return await self._send_built_packet(packet_bytes, packet_id, label="telemetry")
-
-    async def send_telemetry_reply(self, original) -> SendResult:
-        """Reply to an inbound telemetry request addressed to this node."""
-        if not self.meshtastic_enabled:
-            return SendResult(success=False, protocol="meshtastic", error="TX unavailable")
-
-        builder = self._get_builder()
-        if builder is None or not hasattr(builder, "build_telemetry_reply"):
-            return SendResult(success=False, protocol="meshtastic", error="Builder unavailable")
-
-        try:
-            requester = int(original.source_id, 16)
-            request_id = int(original.packet_id, 16)
-        except ValueError:
-            return SendResult(success=False, protocol="meshtastic", error="Invalid source id")
-
-        payload = original.decoded_payload or {}
-        variant = payload.get("telemetry_variant", "device_metrics")
-        if variant == "local_stats":
-            metrics = (
-                self._local_stats_provider() if self._local_stats_provider else {}
-            )
-        else:
-            metrics = (
-                self._device_metrics_provider() if self._device_metrics_provider else {}
-            )
-
-        packet_id = self._next_packet_id()
-        channel_hash = original.channel_hash
-        _, channel_key = self._resolve_channel_by_hash(channel_hash)
-        recipient_pubkey = self._recipient_pubkey_for_reply(
-            original, requester, self._crypto
-        )
-        if channel_hash == 0 and recipient_pubkey is None:
             return SendResult(
                 success=False,
                 protocol="meshtastic",
-                error="No public_key for PKI telemetry reply recipient",
+                error="Meshtastic TX not available",
             )
-        configured = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
-        hop_limit, hop_start = self._reply_hop_fields(original, configured)
-
-        build_kwargs = {
-            "source_id": self._source_node_id,
-            "dest": requester,
-            "packet_id": packet_id,
-            "request_id": request_id,
-            "variant": variant,
-            "telemetry_time": int(time.time()),
-            "channel_key": channel_key,
-            "channel_hash": channel_hash,
-            "hop_limit": hop_limit,
-            "hop_start": hop_start,
-            "recipient_public_key": recipient_pubkey,
-        }
-        if variant == "local_stats":
-            build_kwargs.update(
-                {
-                    "uptime_seconds": int(metrics.get("uptime_seconds", 0)),
-                    "channel_utilization": float(
-                        metrics.get("channel_utilization", 0.0)
-                    ),
-                    "air_util_tx": float(metrics.get("air_util_tx", 0.0)),
-                    "num_packets_tx": int(metrics.get("num_packets_tx", 0)),
-                    "num_packets_rx": int(metrics.get("num_packets_rx", 0)),
-                    "num_packets_rx_bad": int(metrics.get("num_packets_rx_bad", 0)),
-                    "num_online_nodes": int(metrics.get("num_online_nodes", 0)),
-                    "num_total_nodes": int(metrics.get("num_total_nodes", 0)),
-                    "num_tx_relay": int(metrics.get("num_tx_relay", 0)),
-                }
-            )
-            noise_floor = metrics.get("noise_floor")
-            if noise_floor is not None:
-                build_kwargs["noise_floor"] = int(noise_floor)
-        else:
-            build_kwargs.update(
-                {
-                    "battery_level": int(metrics.get("battery_level", 101)),
-                    "voltage": float(metrics.get("voltage", 5.0)),
-                    "channel_utilization": float(
-                        metrics.get("channel_utilization", 0.0)
-                    ),
-                    "air_util_tx": float(metrics.get("air_util_tx", 0.0)),
-                    "uptime_seconds": int(metrics.get("uptime_seconds", 0)),
-                }
-            )
-
-        packet_bytes = builder.build_telemetry_reply(**build_kwargs)
-        if packet_bytes is None:
-            return SendResult(
-                success=False, protocol="meshtastic", error="Telemetry reply build failed"
-            )
-
-        return await self._send_built_packet(
-            packet_bytes, packet_id, label="telemetry reply"
-        )
-
-    async def send_position(
-        self,
-        latitude: float,
-        longitude: float,
-        altitude: float | None = None,
-    ) -> SendResult:
-        if not self.meshtastic_enabled:
-            return SendResult(success=False, protocol="meshtastic", error="TX unavailable")
 
         builder = self._get_builder()
-        if builder is None or not hasattr(builder, "build_position"):
-            return SendResult(success=False, protocol="meshtastic", error="Builder unavailable")
+        if builder is None or not hasattr(builder, "build_admin_message"):
+            return SendResult(
+                success=False,
+                protocol="meshtastic",
+                error="Admin packet builder unavailable",
+            )
+
+        dest_int = self._resolve_destination(destination, Protocol.MESHTASTIC)
+        if dest_int in RESERVED_NODE_IDS:
+            return SendResult(
+                success=False,
+                protocol="meshtastic",
+                error="Invalid destination node",
+            )
 
         packet_id = self._next_packet_id()
-        channel_hash, channel_key = self._resolve_channel(0)
         hop_limit = self._config.hop_limit if self._config else DEFAULT_HOP_LIMIT
+        try:
+            packet_bytes = builder.build_admin_message(
+                admin_payload=admin_payload,
+                dest=dest_int,
+                source_id=self._source_node_id,
+                packet_id=packet_id,
+                admin_key=admin_key,
+                admin_channel_name=admin_channel_name,
+                hop_limit=hop_limit,
+                hop_start=hop_limit,
+                want_ack=want_ack,
+            )
+        except Exception as exc:
+            logger.exception("Admin packet build failed")
+            return SendResult(
+                success=False,
+                protocol="meshtastic",
+                packet_id=f"{packet_id:08x}",
+                error=f"Admin packet build failed: {exc}",
+            )
 
-        packet_bytes = builder.build_position(
-            source_id=self._source_node_id,
-            packet_id=packet_id,
-            latitude=latitude,
-            longitude=longitude,
-            altitude=altitude,
-            channel_key=channel_key,
-            channel_hash=channel_hash,
-            hop_limit=hop_limit,
-            hop_start=hop_limit,
-        )
         if packet_bytes is None:
-            return SendResult(success=False, protocol="meshtastic", error="Position build failed")
+            return SendResult(
+                success=False,
+                protocol="meshtastic",
+                packet_id=f"{packet_id:08x}",
+                error="Admin packet build returned None",
+            )
 
-        return await self._send_built_packet(packet_bytes, packet_id, label="position")
+        logger.info(
+            "TX ADMIN: dest=%08x src=%08x id=%08x channel=%r len=%d",
+            dest_int,
+            self._source_node_id,
+            packet_id,
+            admin_channel_name,
+            len(packet_bytes),
+        )
 
-    async def _send_built_packet(
-        self, packet_bytes: bytes, packet_id: int, *, label: str
-    ) -> SendResult:
         tx_pkt = self._build_hal_packet(packet_bytes)
         airtime_ms = await self._get_airtime(tx_pkt)
 
@@ -663,7 +416,6 @@ class TxService:
         if result_code == 0:
             if self._duty:
                 self._duty.record_tx(airtime_ms)
-            logger.info("TX %s OK: id=%08x airtime=%dms", label, packet_id, airtime_ms)
             return SendResult(
                 success=True,
                 protocol="meshtastic",
@@ -676,6 +428,7 @@ class TxService:
             protocol="meshtastic",
             packet_id=f"{packet_id:08x}",
             error=f"lgw_send returned {result_code}",
+            airtime_ms=airtime_ms,
         )
 
     async def send_raw_relay(
@@ -981,68 +734,6 @@ class TxService:
         except (IndexError, Exception):
             logger.debug("Channel hash fallback to 0x08", exc_info=True)
             return 0x08, None
-
-    @staticmethod
-    def _build_traceroute_reply_data(
-        original, rx_snr: float | None
-    ) -> tuple[list[int], list[int], list[int], list[int]]:
-        """Build RouteDiscovery fields like Meshtastic firmware at the destination.
-
-        Relays append node ids plus SNR on the way in. The target only appends the
-        final-hop SNR (SNRonly) and does not add itself to ``route``. Meshtastic 2.5+
-        also expects ``route_back`` / ``snr_back`` on the response.
-        """
-        payload = original.decoded_payload or {}
-        route_nodes: list[int] = []
-        for node_hex in payload.get("route") or []:
-            try:
-                route_nodes.append(int(node_hex, 16))
-            except (TypeError, ValueError):
-                continue
-
-        snr_towards: list[int] = []
-        for val in payload.get("snr_towards") or []:
-            try:
-                snr_towards.append(int(val))
-            except (TypeError, ValueError):
-                continue
-
-        encoded_snr: int | None = None
-        if rx_snr is not None:
-            encoded_snr = int(round(float(rx_snr) * 4))
-
-        if encoded_snr is not None:
-            snr_towards.append(encoded_snr)
-
-        requester = int(original.source_id, 16)
-        route_back = [requester]
-        snr_back = [encoded_snr] if encoded_snr is not None else []
-
-        return route_nodes, snr_towards, route_back, snr_back
-
-    def _resolve_channel_by_hash(self, channel_hash: int) -> tuple[int, bytes | None]:
-        """Resolve encryption key from a captured on-air channel hash."""
-        if self._crypto is None:
-            return channel_hash, None
-        try:
-            primary_name = self._primary_channel_name
-            all_keys = self._crypto.get_all_keys()
-            if all_keys:
-                primary_hash = self._crypto.compute_channel_hash(
-                    primary_name, all_keys[0]
-                )
-                if primary_hash == channel_hash:
-                    return channel_hash, all_keys[0]
-            for i, (ch_name, key) in enumerate(self._crypto._keys.items(), start=1):
-                if i < len(all_keys):
-                    h = self._crypto.compute_channel_hash(ch_name, all_keys[i])
-                    if h == channel_hash:
-                        return channel_hash, all_keys[i]
-            if all_keys:
-                return channel_hash, all_keys[0]
-        except Exception:
-            logger.debug("Channel-by-hash lookup failed", exc_info=True)
-        return channel_hash, None
 
     def _get_preset_name(self) -> str:
         """Derive the Meshtastic modem preset display name from radio params."""

--- a/tests/test_admin_reader.py
+++ b/tests/test_admin_reader.py
@@ -1,0 +1,133 @@
+"""Unit tests for remote ADMIN config read (PR 15)."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from meshtastic.protobuf import admin_pb2, config_pb2, mesh_pb2
+
+from src.admin.config_decode import _redact_value, message_to_redacted_dict
+from src.admin.pending_store import PendingConfigStore
+from src.admin.reader import AdminConfigError, AdminConfigReader, PORTNUM_ADMIN
+from src.decode.crypto_service import CryptoService
+from src.models.packet import Packet, PacketType, Protocol
+from src.transmit.meshtastic_builder import MeshtasticPacketBuilder
+
+
+class TestAdminMessageBuild(unittest.TestCase):
+    def test_device_config_request_serializes(self):
+        msg = admin_pb2.AdminMessage()
+        msg.get_config_request = admin_pb2.AdminMessage.DEVICE_CONFIG
+        self.assertEqual(msg.SerializeToString(), b"\x28\x00")
+
+    def test_owner_request_serializes(self):
+        msg = admin_pb2.AdminMessage()
+        msg.get_owner_request = True
+        self.assertEqual(msg.SerializeToString(), b"\x18\x01")
+
+
+class TestConfigRedaction(unittest.TestCase):
+    def test_psk_fields_redacted(self):
+        raw = {
+            "security": {"private_key": "secret", "public_key": "pub"},
+            "lora": {"bandwidth": 250, "psk": "hide-me"},
+        }
+        out = _redact_value(raw)
+        self.assertEqual(out["security"]["private_key"], "***")
+        self.assertEqual(out["security"]["public_key"], "***")
+        self.assertEqual(out["lora"]["psk"], "***")
+        self.assertEqual(out["lora"]["bandwidth"], 250)
+
+    def test_message_to_dict_keeps_safe_fields(self):
+        cfg = config_pb2.Config()
+        cfg.lora.bandwidth = 250
+        out = message_to_redacted_dict(cfg)
+        self.assertEqual(out["lora"]["bandwidth"], 250)
+
+
+class TestPendingStore(unittest.TestCase):
+    def test_debounce_blocks_second_request(self):
+        store = PendingConfigStore()
+        store.begin("a3f2b1c0", section="device", packet_id="00000001", expected_response="get_config_response")
+        ok, _ = store.can_request("a3f2b1c0")
+        self.assertFalse(ok)
+
+
+class TestAdminPacketBuild(unittest.TestCase):
+    def test_build_admin_packet_encrypts(self):
+        crypto = CryptoService(default_key_b64="AQ==")
+        admin_key = crypto._expand_key(b"\x01")
+        builder = MeshtasticPacketBuilder(crypto)
+        admin_msg = admin_pb2.AdminMessage()
+        admin_msg.get_config_request = admin_pb2.AdminMessage.DEVICE_CONFIG
+        packet = builder.build_admin_message(
+            admin_payload=admin_msg.SerializeToString(),
+            dest=0xA3F2B1C0,
+            source_id=0x12345678,
+            packet_id=99,
+            admin_key=admin_key,
+            admin_channel_name="admin",
+        )
+        self.assertIsNotNone(packet)
+        self.assertGreater(len(packet), 16)
+
+
+class TestAdminResponseConsume(unittest.IsolatedAsyncioTestCase):
+    async def test_consumes_matching_admin_response(self):
+        crypto = CryptoService(default_key_b64="AQ==")
+        admin_key = crypto._expand_key(b"\x01")
+        builder = MeshtasticPacketBuilder(crypto)
+
+        response_admin = admin_pb2.AdminMessage()
+        response_admin.get_config_response.device.role = 2
+        inner = builder._serialize_data(
+            PORTNUM_ADMIN, response_admin.SerializeToString()
+        )
+
+        packet_id = 42
+        source_id = 0xA3F2B1C0
+        ciphertext = crypto.encrypt_meshtastic(inner, packet_id, source_id, key=admin_key)
+        header = builder._build_header(
+            0x12345678,
+            source_id,
+            packet_id,
+            channel_hash=crypto.compute_channel_hash("admin", admin_key),
+        )
+        raw = header + ciphertext
+
+        tx = MagicMock()
+        tx.meshtastic_enabled = True
+        tx.send_admin_message = AsyncMock(
+            return_value=MagicMock(success=True, packet_id="0000002a", error="")
+        )
+
+        reader = AdminConfigReader(
+            tx_service=tx,
+            crypto=crypto,
+            admin_key_b64="AQ==",
+            admin_channel_name="admin",
+            local_node_id=0x12345678,
+        )
+        await reader.request_config("!a3f2b1c0", section="device")
+
+        packet = Packet(
+            packet_id="0000002a",
+            source_id="a3f2b1c0",
+            destination_id="12345678",
+            protocol=Protocol.MESHTASTIC,
+            packet_type=PacketType.ADMIN,
+            raw_radio_packet=raw,
+        )
+        reader.try_consume_packet(packet)
+
+        status = reader.get_status("a3f2b1c0")
+        self.assertEqual(status["status"], "complete")
+        self.assertIn("config", status["config"])
+
+
+class TestAdminReaderUnavailable(unittest.IsolatedAsyncioTestCase):
+    async def test_503_without_admin_key(self):
+        reader = AdminConfigReader(tx_service=MagicMock(), crypto=CryptoService())
+        with self.assertRaises(AdminConfigError) as ctx:
+            await reader.request_config("a3f2b1c0")
+        self.assertEqual(ctx.exception.status_code, 503)

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,90 @@
+"""API route tests for remote ADMIN config read."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.admin.reader import AdminConfigError, AdminConfigReader
+
+
+class TestAdminRoutes(unittest.TestCase):
+    def setUp(self):
+        try:
+            from fastapi import FastAPI
+            from fastapi.testclient import TestClient
+            from src.api.auth.dependencies import require_admin
+            from src.api.auth.jwt_session import ROLE_ADMIN, SessionClaims
+            from src.api.routes import admin_routes
+        except ImportError as exc:
+            raise unittest.SkipTest(f"API test deps unavailable: {exc}") from exc
+
+        self.admin_routes = admin_routes
+
+        def _admin_claims() -> SessionClaims:
+            return SessionClaims(subject="admin", role=ROLE_ADMIN, session_version=1)
+
+        self.reader = MagicMock(spec=AdminConfigReader)
+        self.reader.available = True
+        self.reader.get_status.return_value = {
+            "node_id": "a3f2b1c0",
+            "status": "idle",
+            "section": None,
+            "config": None,
+            "error": "",
+        }
+        self.reader.request_config = AsyncMock(
+            return_value={
+                "node_id": "a3f2b1c0",
+                "request_id": "abc",
+                "status": "pending",
+                "section": "device",
+                "packet_id": "00000001",
+            }
+        )
+
+        admin_routes.init_routes(reader=self.reader)
+        self.app = FastAPI()
+        self.app.dependency_overrides[require_admin] = _admin_claims
+        from src.api.audit.dependencies import get_audit_writer
+
+        audit = MagicMock()
+
+        class _Ctx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args, **kwargs):
+                return False
+
+        audit.timed_action.return_value = _Ctx()
+        self.app.dependency_overrides[get_audit_writer] = lambda: audit
+        self.app.include_router(admin_routes.router)
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        self.admin_routes.reset_routes()
+
+    def test_status_endpoint(self):
+        self.reader.available = True
+        resp = self.client.get("/api/admin/remote-config/status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["available"])
+
+    def test_request_config_success(self):
+        resp = self.client.post(
+            "/api/admin/nodes/a3f2b1c0/config/request",
+            json={"section": "device"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "pending")
+        self.reader.request_config.assert_awaited_once()
+
+    def test_request_config_maps_admin_error(self):
+        self.reader.request_config = AsyncMock(
+            side_effect=AdminConfigError("no key", status_code=503)
+        )
+        resp = self.client.post(
+            "/api/admin/nodes/a3f2b1c0/config/request",
+            json={"section": "device"},
+        )
+        self.assertEqual(resp.status_code, 503)

--- a/tests/test_admin_writer.py
+++ b/tests/test_admin_writer.py
@@ -1,0 +1,78 @@
+"""Unit tests for remote ADMIN config write (PR 16)."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from meshtastic.protobuf import admin_pb2
+
+from src.admin.reader import AdminConfigError, AdminConfigReader
+from src.admin.write_store import WriteOperationStore
+from src.admin.writer import AdminConfigWriter, ROLE_CONFIRM_TOKEN
+from src.transmit.tx_service import SendResult
+
+
+class TestAdminWriterValidation(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.reader = MagicMock(spec=AdminConfigReader)
+        self.reader.available = True
+        self.reader.send_admin_to_node = AsyncMock(
+            return_value=SendResult(success=True, packet_id="00000001")
+        )
+        self.writer = AdminConfigWriter(
+            reader=self.reader,
+            tx_service=MagicMock(meshtastic_enabled=True),
+            write_store=WriteOperationStore(),
+        )
+
+    async def test_role_requires_confirm(self):
+        with self.assertRaises(AdminConfigError) as ctx:
+            await self.writer.apply_changes("a3f2b1c0", role=2)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("CONFIRM", str(ctx.exception))
+
+    async def test_rejects_empty_payload(self):
+        with self.assertRaises(AdminConfigError) as ctx:
+            await self.writer.apply_changes("a3f2b1c0")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_owner_write_sends_admin(self):
+        result = await self.writer.apply_changes(
+            "a3f2b1c0",
+            long_name="Mesh Node",
+            short_name="MN",
+        )
+        self.assertEqual(result["status"], "verifying")
+        self.reader.send_admin_to_node.assert_awaited()
+        call_args = self.reader.send_admin_to_node.await_args
+        admin_msg = call_args.args[1]
+        self.assertTrue(admin_msg.HasField("set_owner"))
+
+    async def test_role_write_with_confirm(self):
+        await self.writer.apply_changes(
+            "a3f2b1c0",
+            role=2,
+            role_confirm=ROLE_CONFIRM_TOKEN,
+        )
+        admin_msg = self.reader.send_admin_to_node.await_args.args[1]
+        self.assertEqual(admin_msg.set_config.device.role, 2)
+
+    async def test_telemetry_module_write(self):
+        await self.writer.apply_changes(
+            "a3f2b1c0",
+            telemetry_interval_secs=300,
+        )
+        admin_msg = self.reader.send_admin_to_node.await_args.args[1]
+        self.assertEqual(
+            admin_msg.set_module_config.telemetry.device_update_interval,
+            300,
+        )
+
+
+class TestWriteStoreDebounce(unittest.TestCase):
+    def test_blocks_rapid_writes(self):
+        store = WriteOperationStore()
+        store.begin("a3f2b1c0", changes={"role": 2}, verify_sections=["device"])
+        store.mark_verifying("a3f2b1c0", ["00000001"])
+        ok, _ = store.can_write("a3f2b1c0")
+        self.assertFalse(ok)


### PR DESCRIPTION
## Summary

- Adds **limited** remote Meshtastic config **writes** via ADMIN portnum (names, role, screen timeout, telemetry interval)
- Role changes require typing `CONFIRM` in `DangerousModal`; post-write automatic read-back verifies applied state
- Builds on PR #86 read path — includes full ADMIN read + write stack

Part of **Master PR Roadmap #16** (FR4). **Highest-risk PR in the roadmap** — ADMIN write TX.

## Writable fields

| Field | Notes |
|-------|-------|
| `long_name` / `short_name` | Owner ADMIN message |
| `role` | Device config — requires `role_confirm: "CONFIRM"` |
| `screen_on_secs` | Display config (0–600) |
| `telemetry_interval_secs` | Module telemetry config (30–86400) |

**Blocked:** LoRa frequency, PSK/security, factory reset, channel keys.

## Risks / notes

- Wrong admin PSK or offline node → write ACK may succeed but verify times out
- Role changes affect mesh routing behavior — extra confirmation required
- Multiple ADMIN packets per apply when several fields change
- Audit: `admin.config_write` logs target + changed fields only (no secrets)

## Test plan

- [x] `python -m unittest tests.test_admin_reader tests.test_admin_writer -v` (14 tests)
- [ ] Shared admin channel on Meshpoint + test node
- [ ] Change long/short name — verify owner read-back
- [ ] Change role with CONFIRM modal — verify device.role in read-back
- [ ] Change telemetry interval — verify module telemetry read-back
- [ ] Confirm LoRa/PSK fields rejected server-side

## AI-assisted

PR description and implementation assisted by Claude. Follows PR #86 patterns (`TxService.send_admin_message`, audit, node drawer).
