### PR TITLE
Drop serial Meshtastic self-telemetry (-100 dBm noise)

### DIFF
--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -12,6 +12,60 @@ from src.models.signal import SignalMetrics
 logger = logging.getLogger(__name__)
 
 
+class SerialSelfOriginFilter:
+    """Drops a USB stick's self-telemetry/nodeinfo; keeps its own text.
+
+    meshtastic-python publishes the stick's locally originated beacons on
+    the same ``meshtastic.receive`` topic as over-the-air packets. Those
+    beacons have no real RF signal (firmware leaves rxRssi/rxSnr at 0),
+    so the pipeline would otherwise store spammy −100 dBm readings.
+
+    Text from a BLE/WiFi client on the same stick is exempt: it is real
+    chat content and must reach Messages even though ``from`` is the
+    stick's own node id.
+
+    Credit: javastraat/meshpoint ``db4de9f`` + ``c190b3e``.
+    """
+
+    _TEXT_PORTNUMS = frozenset({"TEXT_MESSAGE_APP", 1})
+
+    def __init__(self, own_node_num: Optional[int] = None) -> None:
+        self._own_node_num = own_node_num
+
+    @property
+    def own_node_num(self) -> Optional[int]:
+        return self._own_node_num
+
+    def set_own_node_num(self, node_num: Optional[int]) -> None:
+        self._own_node_num = node_num
+
+    @staticmethod
+    def read_own_node_num(interface) -> Optional[int]:
+        """Best-effort read of ``interface.myInfo.my_node_num``."""
+        try:
+            return int(interface.myInfo.my_node_num)
+        except Exception:
+            logger.debug(
+                "Could not read own node number from serial interface",
+                exc_info=True,
+            )
+            return None
+
+    def should_drop(self, packet: dict) -> bool:
+        if self._own_node_num is None:
+            return False
+        if packet.get("from") != self._own_node_num:
+            return False
+        return not self._is_text_message(packet)
+
+    @classmethod
+    def _is_text_message(cls, packet: dict) -> bool:
+        decoded = packet.get("decoded")
+        if not isinstance(decoded, dict):
+            return False
+        return decoded.get("portnum") in cls._TEXT_PORTNUMS
+
+
 class SerialCaptureSource(CaptureSource):
     """Captures packets from a Meshtastic radio connected via USB serial.
 
@@ -29,6 +83,7 @@ class SerialCaptureSource(CaptureSource):
         self._baud = baud
         self._interface = None
         self._running = False
+        self._self_origin = SerialSelfOriginFilter()
         self._queue: asyncio.Queue[RawCapture] = asyncio.Queue(maxsize=500)
 
     @property
@@ -51,12 +106,22 @@ class SerialCaptureSource(CaptureSource):
             else:
                 self._interface = meshtastic.serial_interface.SerialInterface()
 
+            own_node = SerialSelfOriginFilter.read_own_node_num(self._interface)
+            self._self_origin.set_own_node_num(own_node)
+
             pub.subscribe(self._on_receive, "meshtastic.receive")
             self._running = True
-            logger.info(
-                "Serial capture started on %s",
-                self._port or "auto-detect",
-            )
+            if own_node is not None:
+                logger.info(
+                    "Serial capture started on %s (own_node=%08x)",
+                    self._port or "auto-detect",
+                    own_node,
+                )
+            else:
+                logger.info(
+                    "Serial capture started on %s",
+                    self._port or "auto-detect",
+                )
         except ImportError:
             logger.error(
                 "meshtastic package not installed. "
@@ -69,6 +134,7 @@ class SerialCaptureSource(CaptureSource):
 
     async def stop(self) -> None:
         self._running = False
+        self._self_origin.set_own_node_num(None)
         if self._interface:
             try:
                 self._interface.close()
@@ -104,6 +170,13 @@ class SerialCaptureSource(CaptureSource):
 
     def _packet_to_raw_capture(self, packet: dict) -> Optional[RawCapture]:
         """Convert a meshtastic-python packet dict to a RawCapture."""
+        if self._self_origin.should_drop(packet):
+            logger.debug(
+                "Dropping self-originated non-text packet from own node %08x",
+                self._self_origin.own_node_num,
+            )
+            return None
+
         raw_bytes = packet.get("raw", b"")
         if isinstance(raw_bytes, str):
             raw_bytes = bytes.fromhex(raw_bytes)

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -1,0 +1,136 @@
+"""Serial capture: self-origin filter (javastraat A1 rewrite)."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from src.capture.serial_source import SerialCaptureSource, SerialSelfOriginFilter
+
+
+class SerialSelfOriginFilterTest(unittest.TestCase):
+    """Stick self-telemetry/nodeinfo must drop; own text must pass."""
+
+    def test_telemetry_from_own_node_is_dropped(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertTrue(
+            filt.should_drop(
+                {
+                    "from": 0x09D406F4,
+                    "to": 0xFFFFFFFF,
+                    "decoded": {"portnum": "TELEMETRY_APP", "payload": ""},
+                }
+            )
+        )
+
+    def test_nodeinfo_from_own_node_is_dropped(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertTrue(
+            filt.should_drop(
+                {
+                    "from": 0x09D406F4,
+                    "decoded": {"portnum": "NODEINFO_APP"},
+                }
+            )
+        )
+
+    def test_self_originated_text_message_is_not_dropped(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertFalse(
+            filt.should_drop(
+                {
+                    "from": 0x09D406F4,
+                    "to": 0xFFFFFFFF,
+                    "decoded": {"portnum": "TEXT_MESSAGE_APP", "payload": ""},
+                }
+            )
+        )
+
+    def test_text_portnum_numeric_is_not_dropped(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertFalse(
+            filt.should_drop(
+                {
+                    "from": 0x09D406F4,
+                    "decoded": {"portnum": 1},
+                }
+            )
+        )
+
+    def test_packet_from_remote_node_is_not_dropped(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertFalse(
+            filt.should_drop({"from": 0xAABBCCDD, "raw": "aabb"})
+        )
+
+    def test_unknown_own_node_num_does_not_drop(self):
+        filt = SerialSelfOriginFilter(own_node_num=None)
+        self.assertFalse(
+            filt.should_drop(
+                {
+                    "from": 0x09D406F4,
+                    "decoded": {"portnum": "TELEMETRY_APP"},
+                }
+            )
+        )
+
+    def test_missing_from_field_does_not_drop(self):
+        filt = SerialSelfOriginFilter(own_node_num=0x09D406F4)
+        self.assertFalse(filt.should_drop({"raw": "aabbccddeeff"}))
+
+    def test_read_own_node_num_from_interface(self):
+        iface = SimpleNamespace(myInfo=SimpleNamespace(my_node_num=0xDEADBEEF))
+        self.assertEqual(
+            SerialSelfOriginFilter.read_own_node_num(iface),
+            0xDEADBEEF,
+        )
+
+    def test_read_own_node_num_missing_returns_none(self):
+        self.assertIsNone(SerialSelfOriginFilter.read_own_node_num(object()))
+
+
+class SerialCaptureSourceDropTest(unittest.TestCase):
+    """End-to-end: filter wired into ``_packet_to_raw_capture``."""
+
+    def test_own_telemetry_returns_none(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._self_origin.set_own_node_num(0x09D406F4)
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0x09D406F4,
+                "to": 0xFFFFFFFF,
+                "decoded": {"portnum": "TELEMETRY_APP", "payload": ""},
+                "raw": "aabbccddeeff",
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_own_text_returns_raw_capture(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._self_origin.set_own_node_num(0x09D406F4)
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0x09D406F4,
+                "to": 0xFFFFFFFF,
+                "raw": "aabbccddeeff",
+                "decoded": {"portnum": "TEXT_MESSAGE_APP", "payload": ""},
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.capture_source, "serial")
+
+    def test_remote_packet_returns_raw_capture(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._self_origin.set_own_node_num(0x09D406F4)
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0xAABBCCDD,
+                "to": 0xFFFFFFFF,
+                "raw": "aabbccddeeff",
+            }
+        )
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wave A1 from the javastraat pluck plan: drop a USB stick's self-originated non-text packets (telemetry/nodeinfo) that meshtastic-python publishes on the same receive stream as OTA traffic, which showed up as spammy -100 dBm readings.
- Keep text from a BLE/WiFi client on the same stick so Messages still gets real chat.
- Rewrite against official `SerialCaptureSource` (not a blind cherry-pick). Fork credit: `db4de9f`, `c190b3e` (Albert Einstein / javastraat).

Plan: `docs/plans/javastraat-plucks.md` (A1).

## Test plan
- [x] `python -m pytest tests/test_serial_source.py` (12 passed)
- [x] `ruff check` on touched files
- [ ] Hardware: Meshpoint with Meshtastic USB serial capture; confirm self-telemetry no longer fills the packet feed; send a text via phone BLE/WiFi to the stick and confirm it still appears in Messages