### PR TITLE
Fix MeshCore name contamination + sticky conversation titles

### DIFF
--- a/src/api/meshcore_contacts.py
+++ b/src/api/meshcore_contacts.py
@@ -155,28 +155,29 @@ async def sync_meshcore_contacts_to_nodes(
         name = str(contact.get("name", "")).strip()
         if not pk or not name or _is_hex_identifier(name):
             continue
-        prefixes = _meshcore_pubkey_prefixes(pk)
+        # Exact 12-char node_id only (same truncation as meshcore_event_adapter).
+        # Short-prefix LIKE matches used to overwrite unrelated nodes that
+        # shared an 8/10-char prefix (javastraat/meshpoint 52e1f56).
+        node_id_prefix = pk[:12] if len(pk) >= 12 else pk
         short_name = name[:4]
-        for prefix in prefixes:
-            cursor = await coord.node_repo._db.execute(
-                """
-                UPDATE nodes
-                SET long_name = ?,
-                    short_name = CASE
-                        WHEN short_name IS NULL
-                          OR short_name = ''
-                          OR LOWER(LTRIM(short_name, '!')) = LOWER(SUBSTR(LTRIM(node_id, '!'), 1, 4))
-                            THEN ?
-                        ELSE short_name
-                    END
-                WHERE protocol = 'meshcore'
-                  AND LOWER(LTRIM(node_id, '!')) LIKE ?
-                """,
-                (name, short_name, prefix + "%"),
-            )
-            if cursor.rowcount and cursor.rowcount > 0:
-                updated += cursor.rowcount
-                break
+        cursor = await coord.node_repo._db.execute(
+            """
+            UPDATE nodes
+            SET long_name = ?,
+                short_name = CASE
+                    WHEN short_name IS NULL
+                      OR short_name = ''
+                      OR LOWER(LTRIM(short_name, '!')) = LOWER(SUBSTR(LTRIM(node_id, '!'), 1, 4))
+                        THEN ?
+                    ELSE short_name
+                END
+            WHERE protocol = 'meshcore'
+              AND LOWER(LTRIM(node_id, '!')) = ?
+            """,
+            (name, short_name, node_id_prefix),
+        )
+        if cursor.rowcount:
+            updated += cursor.rowcount
 
     if updated:
         await coord.node_repo._db.commit()
@@ -184,14 +185,6 @@ async def sync_meshcore_contacts_to_nodes(
             "MeshCore contact names applied to %d node row(s)", updated,
         )
     return updated
-
-
-def _meshcore_pubkey_prefixes(pubkey: str) -> tuple[str, ...]:
-    """Yield candidate prefixes (longest first) for a node-id LIKE match."""
-    lengths = (16, 12, 10, 8, len(pubkey))
-    return tuple(
-        dict.fromkeys(pubkey[:n] for n in lengths if len(pubkey) >= n)
-    )
 
 
 def _is_hex_identifier(value: str) -> bool:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1005,12 +1005,13 @@ def _setup_message_interception(
                 name = c.get("name", "")
                 if not pk:
                     continue
+                # Canonical 12-hex only. Indexing 8/10/16-char prefixes let
+                # contacts that share a short prefix overwrite each other
+                # (javastraat/meshpoint 52e1f56).
                 canonical = pk[:12].lower() if len(pk) >= 12 else pk.lower()
-                for prefix_len in (8, 10, 12, 16, len(pk)):
-                    prefix = pk[:prefix_len].lower()
-                    mc_pubkey_canon[prefix] = canonical
-                    if name:
-                        mc_name_cache[prefix] = name
+                mc_pubkey_canon[canonical] = canonical
+                if name:
+                    mc_name_cache[canonical] = name
             logger.debug(
                 "MC contact cache refreshed: %d name, %d pubkey entries",
                 len(mc_name_cache), len(mc_pubkey_canon),
@@ -1026,24 +1027,20 @@ def _setup_message_interception(
             return False
 
     def _resolve_mc_display_name(source: str, payload: dict) -> str:
+        # Canonical 12-char only; see _refresh_mc_contacts.
         src_lower = source.lower()
-        for length in (len(src_lower), 12, 8, 16):
-            cached = mc_name_cache.get(src_lower[:length], "")
-            if cached and not _is_hex_only(cached):
-                return cached
+        cached = mc_name_cache.get(src_lower[:12], "")
+        if cached and not _is_hex_only(cached):
+            return cached
         name = payload.get("long_name", "")
         if name and not _is_hex_only(name):
             return name
         return ""
 
     def _normalize_mc_node_id(source: str) -> str:
-        """Map any pubkey prefix to the canonical 12-char lowercase form."""
+        """Map a pubkey to the canonical 12-char lowercase form."""
         src_lower = source.lower()
-        for length in (len(src_lower), 12, 8, 16):
-            canon = mc_pubkey_canon.get(src_lower[:length], "")
-            if canon:
-                return canon
-        return src_lower
+        return mc_pubkey_canon.get(src_lower[:12], "") or src_lower
 
     def on_text_packet(packet: Packet) -> None:
         if packet.packet_type != PacketType.TEXT:
@@ -1137,10 +1134,11 @@ def _setup_message_interception(
             ):
                 src = (packet.source_id or "").lower()
                 if src and src != node_name.lower():
+                    # Exact node_id match only (not an 8-char LIKE prefix).
                     await coord.node_repo._db.execute(
                         "UPDATE nodes SET long_name = ? "
-                        "WHERE LOWER(node_id) LIKE ? AND protocol = 'meshcore'",
-                        (node_name, src[:8] + "%"),
+                        "WHERE LOWER(node_id) = ? AND protocol = 'meshcore'",
+                        (node_name, src),
                     )
                     await coord.node_repo._db.commit()
 
@@ -1148,35 +1146,19 @@ def _setup_message_interception(
                 packet.protocol == Protocol.MESHCORE
                 and (not node_name or _is_hex_only(node_name))
             ):
+                # Exact match only. Removed unscoped mc:% fetch_one that
+                # borrowed an arbitrary companion contact's name.
                 row = await coord.node_repo._db.fetch_one(
                     "SELECT long_name FROM nodes "
-                    "WHERE LOWER(node_id) LIKE ? AND protocol = 'meshcore' "
+                    "WHERE LOWER(node_id) = ? AND protocol = 'meshcore' "
                     "AND long_name IS NOT NULL AND long_name != ''",
-                    (node_id[:8] + "%",),
+                    (node_id.lower(),),
                 )
                 if row:
                     rn = row["long_name"] or ""
                     if rn and not _is_hex_only(rn):
                         node_name = rn
 
-            if (
-                packet.protocol == Protocol.MESHCORE
-                and (not node_name or _is_hex_only(node_name))
-            ):
-                mc_row = await coord.node_repo._db.fetch_one(
-                    "SELECT node_id, long_name FROM nodes "
-                    "WHERE node_id LIKE 'mc:%' AND protocol = 'meshcore' "
-                    "AND node_id NOT IN ('mc:channel')",
-                )
-                if mc_row:
-                    rn = mc_row["long_name"] or mc_row["node_id"][3:]
-                    if rn and not _is_hex_only(rn):
-                        node_name = rn
-                        await coord.node_repo._db.execute(
-                            "UPDATE nodes SET long_name = ? WHERE node_id = ?",
-                            (rn, node_id),
-                        )
-                        await coord.node_repo._db.commit()
             row_id, is_dup = await message_repo.save_received(
                 text=text,
                 node_id=node_id,

--- a/src/storage/message_repository.py
+++ b/src/storage/message_repository.py
@@ -173,8 +173,15 @@ class MessageRepository:
         Set include_overheard=True for monitor mode.
         """
         where_clause = "" if include_overheard else "WHERE direction != 'overheard'"
+        # Prefer latest non-blank node_name so a sent reply (empty name)
+        # does not blank the conversation title (javastraat/meshpoint cda45e5).
         rows = await self._db.fetch_all(
-            f"""SELECT node_id, node_name, protocol, text, timestamp,
+            f"""SELECT node_id,
+                      (SELECT m2.node_name FROM messages m2
+                        WHERE m2.node_id = messages.node_id
+                          AND m2.node_name != ''
+                        ORDER BY m2.timestamp DESC LIMIT 1) as node_name,
+                      protocol, text, timestamp,
                       SUM(CASE WHEN direction = 'received'
                                AND status != 'read' THEN 1 ELSE 0 END) as unread
                FROM messages

--- a/tests/test_meshcore_contact_enrichment.py
+++ b/tests/test_meshcore_contact_enrichment.py
@@ -92,6 +92,33 @@ class TestMeshCoreContactEnrichment(unittest.TestCase):
         self.assertEqual(ridge.long_name, "Ridge Repeater")
         self.assertEqual(valley.long_name, "Valley Node")
 
+    def test_short_prefix_collision_does_not_contaminate(self):
+        # Two nodes share the first 8 hex chars; only the exact 12-char
+        # match may receive the contact name.
+        _run(self.repo.upsert(Node(
+            node_id="e34ef4172778",
+            protocol="meshcore",
+        )))
+        _run(self.repo.upsert(Node(
+            node_id="e34ef4179999",
+            protocol="meshcore",
+            long_name="Keep Me",
+        )))
+
+        updated = _run(sync_meshcore_contacts_to_nodes(
+            self.coord,
+            _MeshCoreTx([{
+                "public_key": "e34ef4172778aaaabbbbcccc",
+                "name": "Ridge Repeater",
+            }]),
+        ))
+
+        self.assertEqual(updated, 1)
+        matched = _run(self.repo.get_by_id("e34ef4172778"))
+        other = _run(self.repo.get_by_id("e34ef4179999"))
+        self.assertEqual(matched.long_name, "Ridge Repeater")
+        self.assertEqual(other.long_name, "Keep Me")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_repository.py
+++ b/tests/test_message_repository.py
@@ -143,6 +143,24 @@ class TestMessageRepository(unittest.TestCase):
         self.assertNotIn("rssi", d)
         self.assertNotIn("snr", d)
 
+    def test_conversation_name_sticks_after_a_reply_with_no_sender_name(self):
+        # Sent replies store blank node_name; conversation title must keep
+        # the last non-blank sender name (javastraat/meshpoint cda45e5).
+        node_id = "broadcast:meshtastic:keyed:2:0x6e"
+        _run(self.repo.save_received(
+            text="Test 123", node_id=node_id,
+            node_name="PD2EMC Meshtastic Tag", protocol="meshtastic",
+        ))
+        _run(self.repo.save_sent(
+            text="reply with blank sender name", node_id=node_id,
+            node_name="", protocol="meshtastic",
+        ))
+
+        convos = _run(self.repo.get_conversations())
+        convo = next(c for c in convos if c.node_id == node_id)
+        self.assertEqual(convo.node_name, "PD2EMC Meshtastic Tag")
+        self.assertEqual(convo.last_message, "reply with blank sender name")
+
     def test_broadcast_node_constants(self):
         self.assertEqual(BROADCAST_NODE_MT, "broadcast:meshtastic")
         self.assertEqual(BROADCAST_NODE_MC, "broadcast:meshcore")


### PR DESCRIPTION
## Summary
- Wave A2: stop MeshCore short-prefix LIKE / contact-cache collisions from writing one node's name onto another; remove the unscoped `mc:%` fetch that borrowed an arbitrary companion contact name.
- Conversation list keeps the latest non-blank `node_name` so a blank sent reply does not regress the title to the raw node_id.
- Rewrite against official code. Fork credit: `52e1f56`, `cda45e5` (Albert Einstein / javastraat).

## Test plan
- [x] `pytest` contact enrichment + message repository + name resolver + migration (27 passed)
- [x] ruff on touched files