### PR TITLE
Clickable channel message sender names (source_id)

### DIFF
--- a/frontend/css/messaging.css
+++ b/frontend/css/messaging.css
@@ -426,6 +426,15 @@
     text-overflow: ellipsis;
 }
 
+.msg-chat__name--clickable {
+    cursor: pointer;
+}
+
+.msg-chat__name--clickable:hover {
+    text-decoration: underline;
+    color: var(--accent-cyan);
+}
+
 .msg-chat__subtitle {
     font-size: 11px;
     color: var(--msg-text-faint);
@@ -607,6 +616,15 @@
     margin-bottom: 2px;
     color: var(--msg-mt);
     opacity: 0.9;
+}
+
+.msg-bubble__sender--clickable {
+    cursor: pointer;
+}
+
+.msg-bubble__sender--clickable:hover {
+    text-decoration: underline;
+    opacity: 1;
 }
 
 .msg-bubble__text { white-space: pre-wrap; }

--- a/frontend/js/messaging_chat.js
+++ b/frontend/js/messaging_chat.js
@@ -21,6 +21,7 @@ class MessagingChat {
         this._allLoaded = false;
         this._renderEmptyState();
         this._headerName.textContent = '';
+        this._headerName.classList.remove('msg-chat__name--clickable');
         this._headerSubtitle.textContent = '';
         this._headerBadge.textContent = '';
         this._headerAvatar.textContent = '';
@@ -40,6 +41,7 @@ class MessagingChat {
         const proto = convo.protocol === 'meshcore' ? 'MC' : 'MT';
 
         this._headerName.textContent = name;
+        this._headerName.classList.toggle('msg-chat__name--clickable', !isChannel);
         this._headerSubtitle.textContent = isChannel
             ? 'Public channel · all listeners on this PSK'
             : 'Direct message';
@@ -203,12 +205,7 @@ class MessagingChat {
         const statusText = msg.status && msg.status !== 'delivered' && msg.status !== 'read'
             ? ` · ${msg.status}` : '';
 
-        let senderHtml = '';
-        if (msg.direction === 'received') {
-            const name = this._receivedSenderLabel(msg);
-            if (name) senderHtml = `<div class="msg-bubble__sender">${this._esc(name)}</div>`;
-        }
-
+        const senderHtml = this._buildSenderHtml(msg);
         const signalHtml = this._buildSignalHtml(msg);
 
         bubble.innerHTML = `
@@ -218,6 +215,23 @@ class MessagingChat {
         `;
 
         this._messagesEl.appendChild(bubble);
+    }
+
+    _buildSenderHtml(msg) {
+        if (msg.direction !== 'received') return '';
+        const name = this._receivedSenderLabel(msg);
+        if (!name) return '';
+        const nid = this._senderNodeId(msg);
+        const attr = nid ? ` data-node-id="${this._esc(nid)}"` : '';
+        const cls = nid ? ' msg-bubble__sender--clickable' : '';
+        return `<div class="msg-bubble__sender${cls}"${attr}>${this._esc(name)}</div>`;
+    }
+
+    /** Real node id for click-through. Channel rows use source_id. */
+    _senderNodeId(msg) {
+        const nid = msg.node_id || '';
+        if (nid.startsWith('broadcast:')) return msg.source_id || null;
+        return nid || null;
     }
 
     _scrollToBottom() {
@@ -277,6 +291,19 @@ class MessagingChat {
             if (this._messagesEl.scrollTop === 0 && !this._allLoaded) {
                 this._loadOlderMessages();
             }
+        });
+
+        this._headerName.addEventListener('click', () => {
+            if (!this._conversation || !window.nodeDrawer) return;
+            const isChannel = (this._conversation.node_id || '').startsWith('broadcast:');
+            if (isChannel) return;
+            window.nodeDrawer.open({ node_id: this._conversation.node_id });
+        });
+
+        this._messagesEl.addEventListener('click', (e) => {
+            const el = e.target.closest('.msg-bubble__sender[data-node-id]');
+            if (!el || !window.nodeDrawer) return;
+            window.nodeDrawer.open({ node_id: el.dataset.nodeId });
         });
     }
 
@@ -338,12 +365,7 @@ class MessagingChat {
             ? new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
             : '';
         const signalHtml = this._buildSignalHtml(msg);
-
-        let senderHtml = '';
-        if (msg.direction === 'received') {
-            const name = this._receivedSenderLabel(msg);
-            if (name) senderHtml = `<div class="msg-bubble__sender">${this._esc(name)}</div>`;
-        }
+        const senderHtml = this._buildSenderHtml(msg);
 
         bubble.innerHTML = `
             ${senderHtml}

--- a/src/api/message_name_resolver.py
+++ b/src/api/message_name_resolver.py
@@ -99,10 +99,14 @@ class MessageNameResolver:
         node_id = out.get("node_id", "")
         stored = (out.get("node_name") or "").strip()
         if node_id.startswith("broadcast:"):
+            # Always resolve the real sender ID (sets source_id on out for
+            # clickable channel names). Do this even when stored name is
+            # already good; skipping left source_id unset (javastraat 35416ee).
+            resolved_name = await self._resolve_broadcast_sender(out)
             if stored and stored.lower() != "broadcast":
                 out["node_name"] = stored
             else:
-                out["node_name"] = await self._resolve_broadcast_sender(out)
+                out["node_name"] = resolved_name
             return out
         out["node_name"] = await self.resolve(
             node_id,
@@ -116,6 +120,7 @@ class MessageNameResolver:
         if pkt_id and self._packet_repo:
             src = await self._packet_repo.get_source_id_by_packet_id(pkt_id)
             if src:
+                message["source_id"] = src
                 return await self.resolve(
                     src,
                     message.get("protocol", ""),

--- a/tests/test_message_name_resolver.py
+++ b/tests/test_message_name_resolver.py
@@ -116,6 +116,49 @@ class TestMessageNameResolver(unittest.TestCase):
         enriched = _run(self.resolver.apply_to_message_dict(raw))
         self.assertEqual(enriched["node_name"], "TestNode")
 
+    def test_broadcast_with_stored_name_still_sets_source_id(self):
+        # Common case: node_name already stored; must still look up
+        # packet source so the Messages UI can make the sender clickable.
+        _run(self.node_repo.upsert(
+            Node(
+                node_id="a1b2c3d4",
+                long_name="TestNode",
+                protocol="meshtastic",
+            )
+        ))
+
+        async def _seed_packet() -> None:
+            await self.packet_repo.insert(Packet(
+                packet_id="pkt-named-1",
+                source_id="a1b2c3d4",
+                destination_id="ffffffff",
+                protocol=Protocol.MESHTASTIC,
+                packet_type=PacketType.TEXT,
+                signal=SignalMetrics(
+                    rssi=-50.0,
+                    snr=8.0,
+                    frequency_mhz=906.875,
+                    spreading_factor=11,
+                    bandwidth_khz=250,
+                ),
+            ))
+            await self.db.commit()
+
+        _run(_seed_packet())
+        _run(self.message_repo.save_received(
+            text="Hey",
+            node_id="broadcast:meshtastic:0",
+            node_name="TestNode",
+            protocol="meshtastic",
+            packet_id="pkt-named-1",
+        ))
+
+        messages = _run(self.message_repo.get_conversation("broadcast:meshtastic:0"))
+        raw = messages[0].to_dict()
+        enriched = _run(self.resolver.apply_to_message_dict(raw))
+        self.assertEqual(enriched["node_name"], "TestNode")
+        self.assertEqual(enriched["source_id"], "a1b2c3d4")
+
     def test_resolve_sender_by_source_id_for_broadcast_lookup(self):
         _run(self.node_repo.upsert(
             Node(


### PR DESCRIPTION
## Summary
- Wave A3: always resolve broadcast `source_id` even when `node_name` is already stored (otherwise channel senders were not clickable).
- Messages UI: clickable sender labels + DM header open the node drawer.
- Fork credit: `35416ee`, `1a9dfb8` (Albert Einstein / javastraat).

## Test plan
- [x] `pytest tests/test_message_name_resolver.py` (5 passed)
- [x] ruff on resolver
- [ ] UI: open a channel conversation with named senders; click sender opens node drawer; DM header click opens drawer; channel header does not