### PR TITLE
capture_source labeling + node band chips

### DIFF
--- a/frontend/css/node_cards.css
+++ b/frontend/css/node_cards.css
@@ -283,6 +283,13 @@
     font-size: 0.55rem;
 }
 
+.nc-chip--band {
+    color: var(--accent-purple);
+    background: rgba(168, 85, 247, 0.1);
+    font-size: 0.55rem;
+    font-weight: 600;
+}
+
 .nc-chip--id {
     color: var(--text-muted);
     font-size: 0.55rem;

--- a/frontend/js/node_cards.js
+++ b/frontend/js/node_cards.js
@@ -345,9 +345,24 @@ class NodeCards {
         if (n.role != null) {
             parts.push(`<span class="nc-chip nc-chip--meta">${this._roleName(n.role)}</span>`);
         }
+        const band = this._bandLabel(n.latest_capture_source);
+        if (band) {
+            parts.push(`<span class="nc-chip nc-chip--band">${band}</span>`);
+        }
         parts.push(`<span class="nc-chip nc-chip--id">!${this._esc(n.node_id)}</span>`);
 
         return `<div class="nc-card__row nc-card__row--meta">${parts.join('')}</div>`;
+    }
+
+    /**
+     * Band from a labelled capture_source (serial_433, meshcore_usb_868).
+     * Not from frequency_mhz: serial stamps a placeholder frequency today.
+     */
+    _bandLabel(captureSource) {
+        if (!captureSource) return null;
+        if (captureSource.endsWith('_433')) return '433 MHz';
+        if (captureSource.endsWith('_868')) return '868 MHz';
+        return null;
     }
 
     _signalBars(rssi) {

--- a/frontend/js/node_drawer.js
+++ b/frontend/js/node_drawer.js
@@ -150,6 +150,8 @@ class NodeDrawer {
         if (n.hardware_model) rows.push(['Hardware', n.hardware_model]);
         if (n.role != null) rows.push(['Role', this._roleName(n.role)]);
         rows.push(['Protocol', (n.protocol || 'meshtastic').toUpperCase()]);
+        const band = this._bandLabel(n.latest_capture_source);
+        if (band) rows.push(['Band', band]);
         if (n.firmware_version) rows.push(['Firmware', n.firmware_version]);
         rows.push(['Node ID', `!${n.node_id}`]);
         rows.push(['First Seen', this._formatDate(n.first_seen)]);
@@ -426,6 +428,14 @@ class NodeDrawer {
         };
         if (typeof role === 'number') return names[role] || `ROLE_${role}`;
         return String(role).toUpperCase();
+    }
+
+    /** Band from labelled capture_source (serial_433, meshcore_usb_868). */
+    _bandLabel(captureSource) {
+        if (!captureSource) return null;
+        if (captureSource.endsWith('_433')) return '433 MHz';
+        if (captureSource.endsWith('_868')) return '868 MHz';
+        return null;
     }
 
     /** @param {number} tempC stored Meshtastic environment temperature (Celsius). */

--- a/src/capture/meshcore_usb_source.py
+++ b/src/capture/meshcore_usb_source.py
@@ -409,7 +409,7 @@ class MeshcoreUsbCaptureSource(CaptureSource):
         return RawCapture(
             payload=json.dumps(envelope).encode("utf-8"),
             signal=signal,
-            capture_source="meshcore_usb",
+            capture_source=self.name,
             protocol_hint=Protocol.MESHCORE,
         )
 

--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -198,7 +198,7 @@ class SerialCaptureSource(CaptureSource):
         return RawCapture(
             payload=raw_bytes,
             signal=signal,
-            capture_source="serial",
+            capture_source=self.name,
             timestamp=datetime.now(timezone.utc),
         )
 

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -263,7 +263,9 @@ class PipelineCoordinator:
             logger.exception("Pipeline error")
 
     async def _process_capture(self, raw: RawCapture) -> None:
-        if raw.capture_source == "meshcore_usb":
+        # Match bare "meshcore_usb" and labelled forms (meshcore_usb_868, …)
+        # so Wave B multi-companion tags still hit the event adapter.
+        if self._is_meshcore_usb_capture(raw.capture_source):
             packet = self._adapt_meshcore_usb(raw)
         else:
             packet = self._router.decode(
@@ -278,6 +280,10 @@ class PipelineCoordinator:
         await self._relay.process_packet(packet)
         self._publish_mqtt(packet)
         self._record_stats(packet)
+
+    @staticmethod
+    def _is_meshcore_usb_capture(source: str) -> bool:
+        return source == "meshcore_usb" or source.startswith("meshcore_usb_")
 
     @staticmethod
     def _adapt_meshcore_usb(raw: RawCapture) -> Optional[Packet]:

--- a/src/storage/node_repository.py
+++ b/src/storage/node_repository.py
@@ -108,6 +108,7 @@ class NodeRepository:
                    p.snr AS latest_snr,
                    p.hop_limit AS latest_hop_limit,
                    p.hop_start AS latest_hop_start,
+                   p.capture_source AS latest_capture_source,
                    t.battery_level AS latest_battery,
                    t.voltage AS latest_voltage,
                    t.temperature AS latest_temperature,
@@ -117,7 +118,7 @@ class NodeRepository:
             FROM nodes n
             LEFT JOIN (
                 SELECT source_id,
-                       rssi, snr, hop_limit, hop_start,
+                       rssi, snr, hop_limit, hop_start, capture_source,
                        ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY timestamp DESC) AS rn
                 FROM packets
             ) p ON p.source_id = n.node_id AND p.rn = 1
@@ -142,6 +143,7 @@ class NodeRepository:
         d = node.to_dict()
         d["latest_rssi"] = row.get("latest_rssi")
         d["latest_snr"] = row.get("latest_snr")
+        d["latest_capture_source"] = row.get("latest_capture_source")
         d["latest_battery"] = row.get("latest_battery")
         d["latest_voltage"] = row.get("latest_voltage")
         d["latest_temperature"] = row.get("latest_temperature")

--- a/tests/test_meshcore_usb.py
+++ b/tests/test_meshcore_usb.py
@@ -672,6 +672,35 @@ class TestMeshcoreUsbSignalStitching(unittest.TestCase):
             "NodeOne's signal",
         )
 
+    def test_wrap_event_tags_capture_source_with_source_name(self):
+        # javastraat d32d121: never hardcode "meshcore_usb" so labelled
+        # multi-companion names (meshcore_usb_868) flow into packets.
+        source = self._make_source()
+        envelope, _ = self._wrap_payload(source, "advertisement", {
+            "public_key": "aaaaaaaaaaaaaaaaaaaa",
+            "adv_name": "Named",
+        })
+        self.assertEqual(envelope.capture_source, source.name)
+        self.assertEqual(envelope.capture_source, "meshcore_usb")
+
+
+class TestMeshcoreUsbCaptureRouting(unittest.TestCase):
+    def test_labelled_meshcore_usb_sources_use_event_adapter(self):
+        from src.coordinator import PipelineCoordinator
+
+        self.assertTrue(
+            PipelineCoordinator._is_meshcore_usb_capture("meshcore_usb")
+        )
+        self.assertTrue(
+            PipelineCoordinator._is_meshcore_usb_capture("meshcore_usb_868")
+        )
+        self.assertFalse(
+            PipelineCoordinator._is_meshcore_usb_capture("serial")
+        )
+        self.assertFalse(
+            PipelineCoordinator._is_meshcore_usb_capture("concentrator")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_node_repository.py
+++ b/tests/test_node_repository.py
@@ -152,6 +152,27 @@ class TestNodeRepository(unittest.TestCase):
         _run(self.db.commit())
         self.assertEqual(_run(self.repo.count_phantom_rows()), 1)
 
+    def test_get_all_with_signal_reports_latest_capture_source(self):
+        # Band UI keys off capture_source labels (e.g. serial_433), not
+        # frequency_mhz placeholders on the serial USB path.
+        node_id = "7d8b98a9"
+        _run(self.repo.upsert(
+            Node(node_id=node_id, long_name="433 Relay", protocol="meshtastic")
+        ))
+        _run(self.db.execute(
+            "INSERT INTO packets "
+            "(packet_id, source_id, destination_id, protocol, packet_type, "
+            " capture_source, timestamp) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("p1", node_id, "ffffffff", "meshtastic", "data",
+             "serial_433", "2026-07-09T12:00:00+00:00"),
+        ))
+        _run(self.db.commit())
+
+        rows = _run(self.repo.get_all_with_signal())
+        row = next(r for r in rows if r["node_id"] == node_id)
+        self.assertEqual(row["latest_capture_source"], "serial_433")
+
     def test_meshcore_display_name_ignores_id_placeholder(self):
         node = Node(
             node_id="abcdef123456",


### PR DESCRIPTION
## Summary
- Wave A4: MeshCore (and serial) RawCapture tags use `self.name` so labelled multi-radio names can flow through; coordinator accepts `meshcore_usb_*` labels for the event adapter.
- Node list/drawer expose `latest_capture_source` and show 433/868 band chips when the source label ends in `_433` / `_868`.
- Fork credit: `d32d121`, `07bd74f` (Albert Einstein / javastraat). Messaging connection-pill batching deferred until Wave B multi-radio UI lands.

## Test plan
- [x] pytest node_repository + meshcore_usb + serial_source (59 passed)
- [x] ruff on touched Python