### PR TITLE
Unmapped channel hashes + name-keyed ChannelHashResolver

### DIFF
--- a/frontend/js/messaging_chat.js
+++ b/frontend/js/messaging_chat.js
@@ -42,9 +42,12 @@ class MessagingChat {
 
         this._headerName.textContent = name;
         this._headerName.classList.toggle('msg-chat__name--clickable', !isChannel);
-        this._headerSubtitle.textContent = isChannel
-            ? 'Public channel · all listeners on this PSK'
-            : 'Direct message';
+        const isUnmapped = (convo.node_id || '').includes(':unmapped:');
+        this._headerSubtitle.textContent = isUnmapped
+            ? "Unmapped channel hash: no local channel matches, can't reply"
+            : isChannel
+                ? 'Public channel · all listeners on this PSK'
+                : 'Direct message';
         this._headerBadge.textContent = proto;
         this._headerBadge.className = 'msg-chat__protocol-badge ' +
             (convo.protocol === 'meshcore' ? 'msg-chat__protocol-badge--mc' : 'msg-chat__protocol-badge--mt');
@@ -59,9 +62,12 @@ class MessagingChat {
         this._messagesEl.innerHTML = '';
         this._lastDayKey = null;
         this._container.classList.remove('msg-chat--empty');
-        this._input.disabled = false;
-        this._sendBtn.disabled = false;
-        this._input.focus();
+        this._input.disabled = isUnmapped;
+        this._sendBtn.disabled = isUnmapped;
+        this._input.placeholder = isUnmapped
+            ? "Can't reply: no matching local channel"
+            : 'Type a message…';
+        if (!isUnmapped) this._input.focus();
         this._loadMessages();
     }
 

--- a/frontend/js/messaging_contacts.js
+++ b/frontend/js/messaging_contacts.js
@@ -90,6 +90,28 @@ class MessagingContacts {
             });
         }
 
+        // Stored broadcast rows not in /api/messages/channels (e.g.
+        // broadcast:meshtastic:unmapped:0xHH). Without this section they
+        // vanish from the sidebar despite being correctly stored.
+        const knownChannelIds = new Set(this._channels.map(ch => ch.node_id));
+        const unmappedConvos = (this._filter === 'all'
+            ? this._conversations
+            : this._conversations.filter(c => c.protocol === this._filter)
+        ).filter(c => c.is_broadcast && !knownChannelIds.has(c.node_id));
+
+        if (unmappedConvos.length > 0) {
+            const label = document.createElement('div');
+            label.className = 'msg-sidebar__section-label';
+            label.textContent = 'Unmapped';
+            label.title = 'Broadcast traffic on a channel hash that does not match any configured channel. Check channel name/PSK config.';
+            this._listEl.appendChild(label);
+
+            unmappedConvos.forEach(convo => {
+                const el = this._buildConvoEl(convo);
+                this._listEl.appendChild(el);
+            });
+        }
+
         const dmConvos = (this._filter === 'all'
             ? this._conversations
             : this._conversations.filter(c => c.protocol === this._filter)
@@ -107,7 +129,7 @@ class MessagingContacts {
             });
         }
 
-        if (filteredChannels.length === 0 && dmConvos.length === 0) {
+        if (filteredChannels.length === 0 && unmappedConvos.length === 0 && dmConvos.length === 0) {
             this._listEl.innerHTML = '<div class="msg-chat__empty">No conversations yet</div>';
         }
     }

--- a/src/api/channel_hash_resolver.py
+++ b/src/api/channel_hash_resolver.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from src.decode.crypto_service import CryptoService
@@ -28,7 +28,13 @@ class ChannelHashResolver:
         primary_channel_name: str,
         channel_keys: dict[str, str],
     ) -> None:
-        """Rebuild the hash map from live crypto keys and config names."""
+        """Rebuild the hash map from live crypto keys and config names.
+
+        Looks up each secondary channel's key by name via
+        ``crypto.get_channel_key`` (not by position in ``get_all_keys``),
+        so config/crypto ordering drift cannot mis-map hashes
+        (javastraat/meshpoint abc2f56).
+        """
         self._hash_to_index.clear()
         self._warned_hashes.clear()
 
@@ -42,26 +48,31 @@ class ChannelHashResolver:
         self._hash_to_index[primary_hash] = 0
 
         for index, ch_name in enumerate(channel_keys.keys(), start=1):
-            if index >= len(all_keys):
-                break
-            ch_hash = crypto.compute_channel_hash(ch_name, all_keys[index])
+            key = crypto.get_channel_key(ch_name)
+            if key is None:
+                continue
+            ch_hash = crypto.compute_channel_hash(ch_name, key)
             self._hash_to_index[ch_hash] = index
 
         logger.info("Channel hash map: %s", self._hash_to_index)
 
-    def lookup(self, channel_hash: int) -> int:
-        """Return dashboard channel index for a packet header hash."""
+    def lookup(self, channel_hash: int) -> Optional[int]:
+        """Return dashboard channel index, or None if unmapped.
+
+        Never defaults to channel 0. Callers must route None to a distinct
+        visible bucket (javastraat/meshpoint 73f692d).
+        """
         mapped = self._hash_to_index.get(channel_hash)
         if mapped is not None:
             return mapped
         if channel_hash not in self._warned_hashes:
             self._warned_hashes.add(channel_hash)
             logger.warning(
-                "Unmapped Meshtastic channel_hash=0x%02x; "
-                "routing broadcast to channel 0",
+                "Unmapped Meshtastic channel_hash=0x%02x; routing to a "
+                "distinct unmapped bucket instead of blending into channel 0",
                 channel_hash,
             )
-        return 0
+        return None
 
     @property
     def mapping(self) -> dict[int, int]:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1064,9 +1064,17 @@ def _setup_message_interception(
                 return
             if packet.protocol == Protocol.MESHCORE:
                 ch_idx = packet.channel_hash or 0
+                node_id = f"broadcast:{packet.protocol.value}:{ch_idx}"
             else:
                 ch_idx = channel_hash_resolver.lookup(packet.channel_hash)
-            node_id = f"broadcast:{packet.protocol.value}:{ch_idx}"
+                if ch_idx is None:
+                    # Distinct bucket per unmapped hash (not LongFast).
+                    node_id = (
+                        f"broadcast:{packet.protocol.value}:"
+                        f"unmapped:0x{packet.channel_hash:02x}"
+                    )
+                else:
+                    node_id = f"broadcast:{packet.protocol.value}:{ch_idx}"
             direction = "received"
         elif is_for_us:
             node_id = packet.source_id or "unknown"

--- a/src/decode/crypto_service.py
+++ b/src/decode/crypto_service.py
@@ -47,6 +47,10 @@ class CryptoService:
         """Drop all non-default channel keys."""
         self._keys.clear()
 
+    def get_channel_key(self, channel_name: str) -> bytes | None:
+        """Return the expanded key for a named channel, if loaded."""
+        return self._keys.get(channel_name)
+
     def set_keypair(self, private_key: bytes, public_key: bytes) -> None:
         """Install the Meshpoint Meshtastic PKI keypair."""
         self._private_key = private_key

--- a/tests/test_channel_hash_resolver.py
+++ b/tests/test_channel_hash_resolver.py
@@ -51,11 +51,40 @@ class TestChannelHashResolver(unittest.TestCase):
         self.assertEqual(self.resolver.lookup(primary_hash), 0)
         self.assertEqual(self.resolver.lookup(private_hash), 1)
 
-    def test_unknown_hash_defaults_to_zero_and_warns_once(self) -> None:
+    def test_rebuild_is_immune_to_crypto_keys_ordering_drift(self) -> None:
+        self.crypto.add_channel_key("Zulu", PRIVATE_PSK_B64)
+        self.crypto.add_channel_key("Alpha", "AQ==")
+
+        self.resolver.rebuild(
+            self.crypto, "LongFast", {"Alpha": "AQ==", "Zulu": PRIVATE_PSK_B64},
+        )
+
+        alpha_hash = self.crypto.compute_channel_hash(
+            "Alpha", self.crypto.get_channel_key("Alpha"),
+        )
+        zulu_hash = self.crypto.compute_channel_hash(
+            "Zulu", self.crypto.get_channel_key("Zulu"),
+        )
+        self.assertEqual(self.resolver.lookup(alpha_hash), 1)
+        self.assertEqual(self.resolver.lookup(zulu_hash), 2)
+
+    def test_rebuild_excludes_keys_not_in_meshtastic_channel_list(self) -> None:
+        self.crypto.add_channel_key("BayMesh", PRIVATE_PSK_B64)
+        self.crypto.add_channel_key("McPublic", PRIVATE_PSK_B64)
+
+        self.resolver.rebuild(self.crypto, "LongFast", {"BayMesh": PRIVATE_PSK_B64})
+
+        self.assertEqual(len(self.resolver.mapping), 2)
+        mc_hash = self.crypto.compute_channel_hash(
+            "McPublic", self.crypto.get_channel_key("McPublic"),
+        )
+        self.assertIsNone(self.resolver.lookup(mc_hash))
+
+    def test_unknown_hash_returns_none_and_warns_once(self) -> None:
         self.resolver.rebuild(self.crypto, "LongFast", {})
         with patch.object(resolver_module.logger, "warning") as warn:
-            self.assertEqual(self.resolver.lookup(0xAB), 0)
-            self.assertEqual(self.resolver.lookup(0xAB), 0)
+            self.assertIsNone(self.resolver.lookup(0xAB))
+            self.assertIsNone(self.resolver.lookup(0xAB))
             warn.assert_called_once()
 
     def test_rebuild_after_crypto_refresh_updates_private_index(self) -> None:
@@ -70,7 +99,7 @@ class TestChannelHashResolver(unittest.TestCase):
             "BayMesh", self.crypto.get_all_keys()[1]
         )
         self.assertEqual(self.resolver.lookup(private_hash), 1)
-        self.assertEqual(self.resolver.lookup(private_hash_before), 0)
+        self.assertIsNone(self.resolver.lookup(private_hash_before))
 
 
 class TestChannelHashResolverPutChannels(unittest.TestCase):
@@ -99,7 +128,7 @@ class TestChannelHashResolverPutChannels(unittest.TestCase):
         private_hash = self.crypto.compute_channel_hash(
             "BayMesh", self.crypto.get_all_keys()[0]
         )
-        self.assertEqual(self.resolver.lookup(private_hash), 0)
+        self.assertIsNone(self.resolver.lookup(private_hash))
 
         response = self.client.put(
             "/api/config/channels",


### PR DESCRIPTION
## Summary
- Wave A5 + A7: `ChannelHashResolver.lookup` returns `None` instead of silently routing to LongFast; inbound broadcasts land in `broadcast:meshtastic:unmapped:0xHH`.
- `rebuild` resolves secondary keys by channel name (via `CryptoService.get_channel_key`), not list position.
- Messages UI: Unmapped sidebar section; compose disabled for unmapped threads.
- Fork credit: `73f692d`, `59d13df`, `758ed56`, `abc2f56`.

## Test plan
- [x] `pytest tests/test_channel_hash_resolver.py` (6 passed)
- [x] ruff on touched Python