### PR TITLE
A6: keyed replies for channel-name mismatch (same PSK)

### DIFF
--- a/frontend/js/messaging.js
+++ b/frontend/js/messaging.js
@@ -128,18 +128,26 @@ class MessagingPanel {
         const isBroadcast = convo.is_broadcast || (convo.node_id || '').startsWith('broadcast:');
         const destination = isBroadcast ? 'broadcast' : convo.node_id;
 
+        // Keyed conversations (same PSK, different remote channel name)
+        // encode key index + remote hash in node_id; echo that hash on TX.
+        const keyedMatch = (convo.node_id || '').match(/:keyed:(\d+):0x([0-9a-f]+)$/i);
+        const channel = keyedMatch ? parseInt(keyedMatch[1], 10) : (convo.channel || 0);
+
         const tempMsg = this._chat.addOptimisticMessage(text, convo.protocol);
 
         try {
+            const body = {
+                text: text,
+                destination: destination,
+                protocol: convo.protocol || 'meshtastic',
+                channel: channel,
+            };
+            if (keyedMatch) body.echo_hash = parseInt(keyedMatch[2], 16);
+
             const res = await fetch('/api/messages/send', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    text: text,
-                    destination: destination,
-                    protocol: convo.protocol || 'meshtastic',
-                    channel: convo.channel || 0,
-                }),
+                body: JSON.stringify(body),
             });
 
             if (!res.ok) {

--- a/frontend/js/messaging_chat.js
+++ b/frontend/js/messaging_chat.js
@@ -38,16 +38,20 @@ class MessagingChat {
 
         const name = convo.node_name || convo.node_id || '';
         const isChannel = (convo.node_id || '').startsWith('broadcast:');
+        // Keyed: same PSK, different remote name (repliable). Unmapped: no key.
+        const isKeyed = /:keyed:\d+:0x[0-9a-f]+$/i.test(convo.node_id || '');
+        const isUnmapped = !isKeyed && (convo.node_id || '').includes(':unmapped:');
         const proto = convo.protocol === 'meshcore' ? 'MC' : 'MT';
 
         this._headerName.textContent = name;
         this._headerName.classList.toggle('msg-chat__name--clickable', !isChannel);
-        const isUnmapped = (convo.node_id || '').includes(':unmapped:');
         this._headerSubtitle.textContent = isUnmapped
             ? "Unmapped channel hash: no local channel matches, can't reply"
-            : isChannel
-                ? 'Public channel · all listeners on this PSK'
-                : 'Direct message';
+            : isKeyed
+                ? 'Same key, different channel name on their side: replies still work'
+                : isChannel
+                    ? 'Public channel · all listeners on this PSK'
+                    : 'Direct message';
         this._headerBadge.textContent = proto;
         this._headerBadge.className = 'msg-chat__protocol-badge ' +
             (convo.protocol === 'meshcore' ? 'msg-chat__protocol-badge--mc' : 'msg-chat__protocol-badge--mt');

--- a/frontend/js/messaging_contacts.js
+++ b/frontend/js/messaging_contacts.js
@@ -91,13 +91,29 @@ class MessagingContacts {
         }
 
         // Stored broadcast rows not in /api/messages/channels (e.g.
-        // broadcast:meshtastic:unmapped:0xHH). Without this section they
-        // vanish from the sidebar despite being correctly stored.
+        // broadcast:meshtastic:unmapped:0xHH or :keyed:N:0xHH).
         const knownChannelIds = new Set(this._channels.map(ch => ch.node_id));
-        const unmappedConvos = (this._filter === 'all'
+        const otherBroadcastConvos = (this._filter === 'all'
             ? this._conversations
             : this._conversations.filter(c => c.protocol === this._filter)
         ).filter(c => c.is_broadcast && !knownChannelIds.has(c.node_id));
+
+        const isKeyed = (nodeId) => /:keyed:\d+:0x[0-9a-f]+$/i.test(nodeId || '');
+        const keyedConvos = otherBroadcastConvos.filter(c => isKeyed(c.node_id));
+        const unmappedConvos = otherBroadcastConvos.filter(c => !isKeyed(c.node_id));
+
+        if (keyedConvos.length > 0) {
+            const label = document.createElement('div');
+            label.className = 'msg-sidebar__section-label';
+            label.textContent = 'Different Channel Name';
+            label.title = 'Same PSK as a configured channel, but the sender named it differently. Replies encrypt with the matching key and echo their hash.';
+            this._listEl.appendChild(label);
+
+            keyedConvos.forEach(convo => {
+                const el = this._buildConvoEl(convo);
+                this._listEl.appendChild(el);
+            });
+        }
 
         if (unmappedConvos.length > 0) {
             const label = document.createElement('div');
@@ -129,7 +145,7 @@ class MessagingContacts {
             });
         }
 
-        if (filteredChannels.length === 0 && unmappedConvos.length === 0 && dmConvos.length === 0) {
+        if (filteredChannels.length === 0 && keyedConvos.length === 0 && unmappedConvos.length === 0 && dmConvos.length === 0) {
             this._listEl.innerHTML = '<div class="msg-chat__empty">No conversations yet</div>';
         }
     }

--- a/src/api/routes/messages.py
+++ b/src/api/routes/messages.py
@@ -58,6 +58,8 @@ class SendRequest(BaseModel):
     protocol: str = "meshtastic"
     channel: int = 0
     want_ack: bool = False
+    # Keyed replies: echo the remote's on-air hash byte (see matched_channel_index).
+    echo_hash: Optional[int] = None
 
 
 @router.post("/send")
@@ -78,9 +80,12 @@ async def send_message(req: SendRequest):
         protocol=req.protocol,
         channel=req.channel,
         want_ack=req.want_ack,
+        echo_hash=req.echo_hash,
     )
 
-    node_id = _resolve_node_id(req.destination, req.protocol, req.channel)
+    node_id = _resolve_node_id(
+        req.destination, req.protocol, req.channel, req.echo_hash,
+    )
     node_name = await _resolve_display_name(node_id, req.protocol)
 
     if result.success:
@@ -282,10 +287,15 @@ def _is_hex_only(s: str) -> bool:
 
 
 def _resolve_node_id(
-    destination: str, protocol: str, channel: int
+    destination: str,
+    protocol: str,
+    channel: int,
+    echo_hash: Optional[int] = None,
 ) -> str:
     dest_lower = destination.lower()
     if dest_lower in ("broadcast", "all", "0", "ffffffff", "ffff"):
+        if echo_hash is not None:
+            return f"broadcast:{protocol}:keyed:{channel}:0x{echo_hash:02x}"
         return f"broadcast:{protocol}:{channel}"
     return destination
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1067,7 +1067,14 @@ def _setup_message_interception(
                 node_id = f"broadcast:{packet.protocol.value}:{ch_idx}"
             else:
                 ch_idx = channel_hash_resolver.lookup(packet.channel_hash)
-                if ch_idx is None:
+                if ch_idx is None and packet.matched_channel_index is not None:
+                    # Same PSK, different remote channel name: keyed bucket.
+                    node_id = (
+                        f"broadcast:{packet.protocol.value}:keyed:"
+                        f"{packet.matched_channel_index}:"
+                        f"0x{packet.channel_hash:02x}"
+                    )
+                elif ch_idx is None:
                     # Distinct bucket per unmapped hash (not LongFast).
                     node_id = (
                         f"broadcast:{packet.protocol.value}:"

--- a/src/decode/meshtastic_decoder.py
+++ b/src/decode/meshtastic_decoder.py
@@ -119,8 +119,9 @@ class MeshtasticDecoder:
                     self._our_node_id,
                 )
 
+        matched_channel_index: Optional[int] = None
         if not decrypted:
-            for key in self._crypto.get_all_keys():
+            for key_index, key in enumerate(self._crypto.get_all_keys()):
                 decrypted_bytes = self._crypto.decrypt_meshtastic(
                     encrypted_payload,
                     header["packet_id"],
@@ -134,6 +135,7 @@ class MeshtasticDecoder:
                 )
                 if decoded_payload is not None:
                     decrypted = True
+                    matched_channel_index = key_index
                     break
 
         if not decrypted and encrypted_payload:
@@ -164,6 +166,7 @@ class MeshtasticDecoder:
             raw_app_payload=raw_app_payload,
             raw_radio_packet=bytes(raw_bytes),
             decrypted=decrypted,
+            matched_channel_index=matched_channel_index,
             signal=signal,
             timestamp=datetime.now(timezone.utc),
         )

--- a/src/models/packet.py
+++ b/src/models/packet.py
@@ -76,6 +76,10 @@ class Packet:
     # legitimate relay rather than a fresh broadcast.
     raw_radio_packet: Optional[bytes] = None
     decrypted: bool = False
+    # Index into crypto.get_all_keys() of the key that decrypted this
+    # packet. Set even when channel_hash does not match a local name+key
+    # hash (remote used a different channel name, same PSK).
+    matched_channel_index: Optional[int] = None
 
     signal: Optional[SignalMetrics] = None
     capture_source: str = "unknown"

--- a/src/transmit/tx_service.py
+++ b/src/transmit/tx_service.py
@@ -148,11 +148,16 @@ class TxService:
         protocol: str = "meshtastic",
         channel: int = 0,
         want_ack: bool = False,
+        echo_hash: int | None = None,
     ) -> SendResult:
-        """Send a text message over the specified protocol."""
+        """Send a text message over the specified protocol.
+
+        ``echo_hash`` stamps the on-air hash byte without changing which
+        channel key encrypts the payload (keyed / name-mismatch replies).
+        """
         if protocol.lower() in ("meshtastic", "mt"):
             return await self._send_meshtastic(
-                text, destination, channel, want_ack
+                text, destination, channel, want_ack, echo_hash
             )
         elif protocol.lower() in ("meshcore", "mc"):
             return await self._send_meshcore(text, destination, channel)
@@ -267,6 +272,7 @@ class TxService:
         destination: int | str,
         channel: int,
         want_ack: bool,
+        echo_hash: int | None = None,
     ) -> SendResult:
         """Build and transmit a Meshtastic packet via the SX1261."""
         if not self.meshtastic_enabled:
@@ -287,6 +293,8 @@ class TxService:
         dest_int = self._resolve_destination(destination, Protocol.MESHTASTIC)
         packet_id = self._next_packet_id()
         channel_hash, channel_key = self._resolve_channel(channel)
+        if echo_hash is not None:
+            channel_hash = echo_hash
         recipient_pubkey = None
         if dest_int != BROADCAST_ADDR_MT and self._crypto is not None:
             recipient_pubkey = self._crypto.lookup_public_key(dest_int)

--- a/tests/test_meshtastic_decoder_matched_channel_index.py
+++ b/tests/test_meshtastic_decoder_matched_channel_index.py
@@ -1,0 +1,94 @@
+"""``MeshtasticDecoder.decode()`` records which configured key decrypted
+a packet, even when its on-air channel_hash doesn't match any locally
+computed name+key hash.
+"""
+
+from __future__ import annotations
+
+import struct
+import unittest
+
+from src.decode.meshtastic_decoder import MeshtasticDecoder
+from src.models.packet import PacketType
+
+
+def _build_header(
+    *,
+    channel_hash: int,
+    dest_id: int = 0xFFFFFFFF,
+    source_id: int = 0xDEADBEEF,
+    packet_id: int = 0x12345678,
+) -> bytes:
+    flags = (3 & 0x07) | ((3 & 0x07) << 5)  # hop_limit=3, hop_start=3
+    return (
+        struct.pack("<III", dest_id, source_id, packet_id)
+        + bytes([flags, channel_hash, 0x00, 0x00])
+    )
+
+
+class _FakeCrypto:
+    """Duck-types CryptoService methods the brute-force loop uses."""
+
+    def __init__(self, keys: list[bytes]) -> None:
+        self._keys = keys
+
+    def get_all_keys(self) -> list[bytes]:
+        return list(self._keys)
+
+    def decrypt_meshtastic(self, encrypted_payload, packet_id, source_id, key=None):
+        return b"DECRYPTED:" + key
+
+
+class TestMatchedChannelIndex(unittest.TestCase):
+    def _decoder_with_payload_matcher(self, crypto, valid_marker: bytes):
+        decoder = MeshtasticDecoder(crypto)
+
+        def fake_decode_payload(self, decrypted):
+            if decrypted == valid_marker:
+                return ({"text": "hi"}, PacketType.TEXT, None, 0)
+            return (None, PacketType.UNKNOWN, None, 0)
+
+        decoder._decode_payload = fake_decode_payload.__get__(decoder)
+        return decoder
+
+    def test_second_configured_key_records_index_1(self):
+        crypto = _FakeCrypto([b"primary-key", b"baymesh-key", b"third-key"])
+        decoder = self._decoder_with_payload_matcher(
+            crypto, valid_marker=b"DECRYPTED:baymesh-key"
+        )
+        raw = _build_header(channel_hash=0x6E) + b"ciphertext-body"
+
+        packet = decoder.decode(raw)
+
+        self.assertIsNotNone(packet)
+        self.assertTrue(packet.decrypted)
+        self.assertEqual(packet.matched_channel_index, 1)
+
+    def test_primary_key_records_index_0(self):
+        crypto = _FakeCrypto([b"primary-key", b"baymesh-key"])
+        decoder = self._decoder_with_payload_matcher(
+            crypto, valid_marker=b"DECRYPTED:primary-key"
+        )
+        raw = _build_header(channel_hash=0x08) + b"ciphertext-body"
+
+        packet = decoder.decode(raw)
+
+        self.assertIsNotNone(packet)
+        self.assertEqual(packet.matched_channel_index, 0)
+
+    def test_no_key_matches_leaves_index_none(self):
+        crypto = _FakeCrypto([b"primary-key", b"baymesh-key"])
+        decoder = self._decoder_with_payload_matcher(
+            crypto, valid_marker=b"DECRYPTED:nothing-will-match-this"
+        )
+        raw = _build_header(channel_hash=0xAB) + b"ciphertext-body"
+
+        packet = decoder.decode(raw)
+
+        self.assertIsNotNone(packet)
+        self.assertFalse(packet.decrypted)
+        self.assertIsNone(packet.matched_channel_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tx_service.py
+++ b/tests/test_tx_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from src.config import TransmitConfig
 from src.models.packet import Protocol
@@ -238,5 +238,63 @@ class TestPersistDerivedNodeId(unittest.TestCase):
         self.assertNotEqual(svc.source_node_id, 0)
 
 
+class TestEchoHashOverride(unittest.IsolatedAsyncioTestCase):
+    """Keyed replies encrypt with the resolved channel key but stamp
+    the remote's on-air hash byte via ``echo_hash``."""
+
+    def _build_tx_service(self):
+        cfg = TransmitConfig(enabled=True, hop_limit=3, node_id=0xC0FFEE42)
+        wrapper = Mock()
+        wrapper.send = Mock(return_value=0)
+        wrapper.get_tx_status = Mock(return_value=2)
+        wrapper.get_time_on_air = Mock(return_value=100)
+
+        tx = TxService(
+            wrapper=wrapper,
+            transmit_config=cfg,
+            persist_derived_node_id=False,
+        )
+        tx._resolve_channel = Mock(return_value=(0x2C, b"the-real-channel-key"))
+
+        builder = Mock()
+        builder.build_text_message = Mock(return_value=b"packet-bytes")
+        tx._get_builder = Mock(return_value=builder)
+
+        hal_packet = Mock(
+            freq_hz=906875000, bandwidth=0, datarate=11, coderate=1,
+            rf_power=17, preamble=16, no_crc=False, no_header=False,
+            invert_pol=False, size=10,
+        )
+        tx._build_hal_packet = Mock(return_value=hal_packet)
+        return tx, builder
+
+    async def test_echo_hash_overrides_recomputed_hash(self):
+        tx, builder = self._build_tx_service()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tx._send_meshtastic(
+                "hi", BROADCAST_ADDR_MT, channel=2, want_ack=False, echo_hash=0x6E,
+            )
+
+        self.assertTrue(result.success)
+        kwargs = builder.build_text_message.call_args.kwargs
+        self.assertEqual(kwargs["channel_hash"], 0x6E)
+        self.assertEqual(kwargs["channel_key"], b"the-real-channel-key")
+
+    async def test_no_echo_hash_keeps_recomputed_hash(self):
+        tx, builder = self._build_tx_service()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tx._send_meshtastic(
+                "hi", BROADCAST_ADDR_MT, channel=2, want_ack=False, echo_hash=None,
+            )
+
+        self.assertTrue(result.success)
+        kwargs = builder.build_text_message.call_args.kwargs
+        self.assertEqual(kwargs["channel_hash"], 0x2C)
+        self.assertEqual(kwargs["channel_key"], b"the-real-channel-key")
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- When a packet decrypts with a configured key but its on-air hash does not match any local name+key hash, bucket it as `broadcast:meshtastic:keyed:{index}:0x{hash}` instead of plain unmapped.
- Replies encrypt with the matched channel key and stamp `echo_hash` so the remote radio accepts the frame.
- Sidebar: **Different Channel Name** section (repliable); true unmapped stays reply-disabled.

Rewritten against official code from fork `4fee04b` (javastraat / Albert Einstein). Not a blind cherry-pick.

## Test plan
- [x] `pytest tests/test_meshtastic_decoder_matched_channel_index.py tests/test_tx_service.py::TestEchoHashOverride`
- [x] ruff clean on touched files
- [ ] Optional hardware: witness phone on same PSK, different channel name; reply from Meshpoint Messages