### PR TITLE
Wave B foundation: serial pre_decoded + MeshPacket reconstruct

### DIFF
--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 from datetime import datetime, timezone
 from typing import AsyncIterator, Optional
@@ -180,8 +181,14 @@ class SerialCaptureSource(CaptureSource):
         raw_bytes = packet.get("raw", b"")
         if isinstance(raw_bytes, str):
             raw_bytes = bytes.fromhex(raw_bytes)
+        elif not isinstance(raw_bytes, (bytes, bytearray)):
+            # meshtastic-python sets packet["raw"] to the MeshPacket
+            # protobuf object, not bytes. Treat as absent so reconstruct runs.
+            raw_bytes = b""
 
-        if not raw_bytes and "decoded" in packet:
+        if not raw_bytes:
+            # Reconstruct even without "decoded": encrypted/decoded share a
+            # oneof, so undecryptable-by-stick traffic has no "decoded" key.
             raw_bytes = self._reconstruct_raw(packet)
 
         if not raw_bytes:
@@ -200,7 +207,41 @@ class SerialCaptureSource(CaptureSource):
             signal=signal,
             capture_source=self.name,
             timestamp=datetime.now(timezone.utc),
+            pre_decoded=self._build_pre_decoded(packet),
         )
+
+    @staticmethod
+    def _build_pre_decoded(packet: dict) -> Optional[dict]:
+        """Portnum + payload when the stick already decrypted locally."""
+        decoded = packet.get("decoded")
+        if not isinstance(decoded, dict):
+            return None
+        portnum_name = decoded.get("portnum")
+        if portnum_name is None:
+            return None
+        try:
+            if isinstance(portnum_name, int):
+                portnum = portnum_name
+            else:
+                from meshtastic.protobuf import portnums_pb2
+
+                portnum = portnums_pb2.PortNum.Value(portnum_name)
+        except (ImportError, ValueError):
+            logger.debug("Unrecognized portnum name %r", portnum_name)
+            return None
+
+        payload_b64 = decoded.get("payload", "")
+        try:
+            payload = base64.b64decode(payload_b64) if payload_b64 else b""
+        except Exception:
+            logger.debug("Could not base64-decode decoded.payload", exc_info=True)
+            payload = b""
+
+        return {
+            "portnum": portnum,
+            "payload": payload,
+            "request_id": decoded.get("requestId", 0),
+        }
 
     @staticmethod
     def _reconstruct_raw(packet: dict) -> bytes:
@@ -230,8 +271,9 @@ class SerialCaptureSource(CaptureSource):
         header = struct.pack("<III", dest, source, pkt_id)
         header += bytes([flags, channel, 0, 0])
 
-        encoded = packet.get("encoded", b"")
+        # MessageToDict base64-encodes the MeshPacket "encrypted" field.
+        encoded = packet.get("encrypted", b"")
         if isinstance(encoded, str):
-            encoded = bytes.fromhex(encoded)
+            encoded = base64.b64decode(encoded)
 
         return header + encoded

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -269,7 +269,10 @@ class PipelineCoordinator:
             packet = self._adapt_meshcore_usb(raw)
         else:
             packet = self._router.decode(
-                raw.payload, signal=raw.signal, protocol_hint=raw.protocol_hint
+                raw.payload,
+                signal=raw.signal,
+                protocol_hint=raw.protocol_hint,
+                pre_decoded=raw.pre_decoded,
             )
         if packet is None:
             return

--- a/src/decode/meshtastic_decoder.py
+++ b/src/decode/meshtastic_decoder.py
@@ -31,7 +31,10 @@ class MeshtasticDecoder:
         self._our_node_id = our_node_id
 
     def decode(
-        self, raw_bytes: bytes, signal: Optional[SignalMetrics] = None
+        self,
+        raw_bytes: bytes,
+        signal: Optional[SignalMetrics] = None,
+        pre_decoded: Optional[dict] = None,
     ) -> Optional[Packet]:
         if len(raw_bytes) < MESHTASTIC_HEADER_SIZE:
             logger.debug("Packet too short: %d bytes", len(raw_bytes))
@@ -49,7 +52,18 @@ class MeshtasticDecoder:
         raw_app_payload: Optional[bytes] = None
         request_id = 0
 
-        if CryptoService.is_pki_packet(
+        if pre_decoded is not None:
+            # Stick already decrypted; ciphertext discarded by protobuf oneof.
+            decoded_payload, packet_type = dispatch_portnum(
+                pre_decoded.get("portnum", -1),
+                pre_decoded.get("payload", b""),
+            )
+            raw_app_payload = pre_decoded.get("payload") or None
+            request_id = pre_decoded.get("request_id", 0)
+            if decoded_payload is not None:
+                decrypted = True
+
+        elif CryptoService.is_pki_packet(
             header["channel_hash"],
             header["dest_id"],
             self._our_node_id,
@@ -120,7 +134,7 @@ class MeshtasticDecoder:
                 )
 
         matched_channel_index: Optional[int] = None
-        if not decrypted:
+        if not decrypted and pre_decoded is None:
             for key_index, key in enumerate(self._crypto.get_all_keys()):
                 decrypted_bytes = self._crypto.decrypt_meshtastic(
                     encrypted_payload,

--- a/src/decode/packet_router.py
+++ b/src/decode/packet_router.py
@@ -40,9 +40,12 @@ class PacketRouter:
         raw_bytes: bytes,
         signal: Optional[SignalMetrics] = None,
         protocol_hint: Optional[Protocol] = None,
+        pre_decoded: Optional[dict] = None,
     ) -> Optional[Packet]:
         if protocol_hint == Protocol.MESHTASTIC:
-            packet = self._meshtastic.decode(raw_bytes, signal)
+            packet = self._meshtastic.decode(
+                raw_bytes, signal, pre_decoded=pre_decoded
+            )
             if packet:
                 logger.info(
                     "Meshtastic packet (hint) type=%s src=%s decrypted=%s",
@@ -59,7 +62,9 @@ class PacketRouter:
                 )
             return packet
 
-        packet = self._meshtastic.decode(raw_bytes, signal)
+        packet = self._meshtastic.decode(
+            raw_bytes, signal, pre_decoded=pre_decoded
+        )
         if packet and packet.decrypted:
             logger.info(
                 "Decoded %s packet (type=%s, src=%s)",

--- a/src/models/packet.py
+++ b/src/models/packet.py
@@ -42,6 +42,10 @@ class RawCapture:
     capture_source: str
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     protocol_hint: Optional[Protocol] = None
+    # Set when an upstream library already decrypted (meshtastic-python
+    # serial): portnum (int) + inner payload (bytes). Header-only
+    # ``payload`` has no ciphertext left to decrypt.
+    pre_decoded: Optional[dict] = None
 
 
 @dataclass

--- a/tests/test_meshtastic_decoder_predecoded.py
+++ b/tests/test_meshtastic_decoder_predecoded.py
@@ -1,0 +1,103 @@
+"""Tests for MeshtasticDecoder.decode()'s pre_decoded fast path.
+
+Covers packets a serial-connected Meshtastic USB stick already
+decrypted locally (protobuf oneof discards ciphertext).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from meshtastic.protobuf import portnums_pb2, telemetry_pb2
+
+from src.decode.crypto_service import CryptoService
+from src.decode.meshtastic_decoder import MeshtasticDecoder
+from src.models.packet import PacketType
+
+
+def _header_only_frame(
+    dest=0xFFFFFFFF,
+    source=0x09D406F4,
+    packet_id=555,
+    hop_limit=3,
+    hop_start=3,
+    channel=0,
+) -> bytes:
+    import struct
+
+    flags = (hop_limit & 0x07) | ((hop_start & 0x07) << 5)
+    return struct.pack("<III", dest, source, packet_id) + bytes(
+        [flags, channel, 0, 0]
+    )
+
+
+class MeshtasticDecoderPreDecodedTest(unittest.TestCase):
+    def setUp(self):
+        self.decoder = MeshtasticDecoder(CryptoService())
+
+    def test_telemetry_portnum_yields_typed_packet_not_unknown(self):
+        tel = telemetry_pb2.Telemetry()
+        tel.device_metrics.battery_level = 87
+        tel.device_metrics.voltage = 4.1
+        pre_decoded = {
+            "portnum": portnums_pb2.PortNum.TELEMETRY_APP,
+            "payload": tel.SerializeToString(),
+            "request_id": 0,
+        }
+
+        packet = self.decoder.decode(
+            _header_only_frame(), pre_decoded=pre_decoded
+        )
+
+        self.assertIsNotNone(packet)
+        self.assertEqual(packet.packet_type, PacketType.TELEMETRY)
+        self.assertTrue(packet.decrypted)
+        self.assertIsNone(packet.encrypted_payload)
+        self.assertEqual(packet.decoded_payload["battery_level"], 87)
+        self.assertAlmostEqual(packet.decoded_payload["voltage"], 4.1, places=2)
+
+    def test_source_and_header_fields_come_from_the_frame(self):
+        pre_decoded = {
+            "portnum": portnums_pb2.PortNum.TELEMETRY_APP,
+            "payload": telemetry_pb2.Telemetry().SerializeToString(),
+        }
+        packet = self.decoder.decode(
+            _header_only_frame(source=0x09D406F4, hop_limit=3, hop_start=3),
+            pre_decoded=pre_decoded,
+        )
+        self.assertEqual(packet.source_id, "09d406f4")
+        self.assertEqual(packet.hop_count, 0)
+
+    def test_request_id_is_attached_to_decoded_payload(self):
+        pre_decoded = {
+            "portnum": portnums_pb2.PortNum.TELEMETRY_APP,
+            "payload": telemetry_pb2.Telemetry().SerializeToString(),
+            "request_id": 99,
+        }
+        packet = self.decoder.decode(
+            _header_only_frame(), pre_decoded=pre_decoded
+        )
+        self.assertEqual(packet.decoded_payload.get("request_id"), 99)
+
+    def test_empty_payload_falls_back_to_unknown_not_encrypted(self):
+        pre_decoded = {"portnum": -1, "payload": b""}
+
+        packet = self.decoder.decode(
+            _header_only_frame(), pre_decoded=pre_decoded
+        )
+
+        self.assertIsNotNone(packet)
+        self.assertNotEqual(packet.packet_type, PacketType.ENCRYPTED)
+
+    def test_too_short_frame_returns_none_even_with_pre_decoded(self):
+        pre_decoded = {
+            "portnum": portnums_pb2.PortNum.TELEMETRY_APP,
+            "payload": b"",
+        }
+        self.assertIsNone(
+            self.decoder.decode(b"\x00" * 4, pre_decoded=pre_decoded)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -132,5 +132,61 @@ class SerialCaptureSourceDropTest(unittest.TestCase):
         self.assertIsNotNone(result)
 
 
+class BuildPreDecodedEarlyExitTest(unittest.TestCase):
+    """Early exits that must not require the meshtastic package."""
+
+    def test_no_decoded_key_returns_none(self):
+        self.assertIsNone(
+            SerialCaptureSource._build_pre_decoded({"raw": "aa"})
+        )
+
+    def test_decoded_not_a_dict_returns_none(self):
+        self.assertIsNone(
+            SerialCaptureSource._build_pre_decoded({"decoded": "not-a-dict"})
+        )
+
+    def test_decoded_missing_portnum_returns_none(self):
+        self.assertIsNone(
+            SerialCaptureSource._build_pre_decoded(
+                {"decoded": {"payload": "AQI="}}
+            )
+        )
+
+
+class ReconstructRawTest(unittest.TestCase):
+    """MeshPacket raw is a protobuf object; encrypted is base64."""
+
+    def test_protobuf_raw_object_triggers_reconstruction(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0xAABBCCDD,
+                "to": 0xFFFFFFFF,
+                "id": 1,
+                "raw": object(),  # MeshPacket stand-in
+                "encrypted": "",
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(len(result.payload), 16)
+
+    def test_encrypted_base64_appended_to_header(self):
+        import base64
+
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        body = base64.b64encode(b"\x01\x02\x03").decode()
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0xAABBCCDD,
+                "to": 0xFFFFFFFF,
+                "id": 1,
+                "raw": object(),
+                "encrypted": body,
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.payload[16:], b"\x01\x02\x03")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Treat meshtastic-python `packet['raw']` protobuf objects as absent and reconstruct headers; read base64 `encrypted` (not hex `encoded`).
- Add `RawCapture.pre_decoded` and thread it through router/coordinator/decoder so stick-local decrypts get real `PacketType`.
- Unblocks A8 (serial channel index vs OTA hash), which needs `_build_pre_decoded` + name routing.

Rewritten from fork `3ac7cf9` + `07c00ba` (javastraat). Not a blind cherry-pick.

## Test plan
- [x] `pytest tests/test_serial_source.py tests/test_meshtastic_decoder_predecoded.py`
- [x] ruff clean
- [ ] Optional: USB Meshtastic stick; locally decrypted packets show Position/Telemetry/etc. not Unknown