### PR TITLE
A8 (receive): serial channel index is not an OTA hash

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -994,6 +994,13 @@ def _setup_message_interception(
     except Exception:
         logger.debug("Failed to build channel hash map", exc_info=True)
 
+    # Stick-local channel name -> Meshpoint index (serial pre_decoded path).
+    name_to_channel_index: dict[str, int] = {}
+    if config.meshtastic.primary_channel_name:
+        name_to_channel_index[config.meshtastic.primary_channel_name] = 0
+    for _i, _name in enumerate(config.meshtastic.channel_keys.keys(), start=1):
+        name_to_channel_index[_name] = _i
+
     async def _refresh_mc_contacts() -> None:
         if not meshcore_tx or not meshcore_tx.connected:
             logger.debug("MC contact refresh skipped: not connected")
@@ -1065,6 +1072,17 @@ def _setup_message_interception(
             if packet.protocol == Protocol.MESHCORE:
                 ch_idx = packet.channel_hash or 0
                 node_id = f"broadcast:{packet.protocol.value}:{ch_idx}"
+            elif packet.remote_channel_name:
+                # Stick reported its local channel by name; hash byte may be
+                # that stick's table index, not a real OTA hash.
+                _idx = name_to_channel_index.get(packet.remote_channel_name)
+                if _idx is not None:
+                    node_id = f"broadcast:{packet.protocol.value}:{_idx}"
+                else:
+                    node_id = (
+                        f"broadcast:{packet.protocol.value}:named:"
+                        f"{packet.remote_channel_name}"
+                    )
             else:
                 ch_idx = channel_hash_resolver.lookup(packet.channel_hash)
                 if ch_idx is None and packet.matched_channel_index is not None:

--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -85,6 +85,7 @@ class SerialCaptureSource(CaptureSource):
         self._interface = None
         self._running = False
         self._self_origin = SerialSelfOriginFilter()
+        self._radio_info: dict = {"channel_table": {}}
         self._queue: asyncio.Queue[RawCapture] = asyncio.Queue(maxsize=500)
 
     @property
@@ -94,6 +95,14 @@ class SerialCaptureSource(CaptureSource):
     @property
     def is_running(self) -> bool:
         return self._running
+
+    def resolve_channel_index(self, name: str) -> Optional[int]:
+        """This stick's channel-table index for ``name``, or None."""
+        table = self._radio_info.get("channel_table") or {}
+        for idx, ch_name in table.items():
+            if ch_name == name:
+                return idx
+        return None
 
     async def start(self) -> None:
         try:
@@ -109,6 +118,17 @@ class SerialCaptureSource(CaptureSource):
 
             own_node = SerialSelfOriginFilter.read_own_node_num(self._interface)
             self._self_origin.set_own_node_num(own_node)
+            try:
+                modem_preset = self._read_modem_preset_name(self._interface)
+                self._radio_info["channel_table"] = self._read_channel_table(
+                    self._interface, modem_preset
+                )
+            except Exception:
+                logger.debug(
+                    "Could not read channel table from serial interface",
+                    exc_info=True,
+                )
+                self._radio_info["channel_table"] = {}
 
             pub.subscribe(self._on_receive, "meshtastic.receive")
             self._running = True
@@ -132,6 +152,37 @@ class SerialCaptureSource(CaptureSource):
         except Exception:
             logger.exception("Failed to open serial interface")
             raise
+
+    @staticmethod
+    def _read_modem_preset_name(interface) -> Optional[str]:
+        try:
+            from meshtastic.protobuf import config_pb2
+
+            lora = interface.localNode.localConfig.lora
+            if not lora.use_preset:
+                return None
+            return config_pb2.Config.LoRaConfig.ModemPreset.Name(lora.modem_preset)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _read_channel_table(
+        interface, modem_preset_name: Optional[str] = None
+    ) -> dict:
+        """Stick channel-table index -> name (for locally decoded packets)."""
+        from meshtastic.protobuf import channel_pb2
+
+        table: dict[int, str] = {}
+        channels = getattr(interface.localNode, "channels", None) or []
+        for ch in channels:
+            if ch.role == channel_pb2.Channel.Role.DISABLED:
+                continue
+            name = ch.settings.name
+            if not name and ch.role == channel_pb2.Channel.Role.PRIMARY:
+                name = modem_preset_name
+            if name:
+                table[ch.index] = name
+        return table
 
     async def stop(self) -> None:
         self._running = False
@@ -210,8 +261,7 @@ class SerialCaptureSource(CaptureSource):
             pre_decoded=self._build_pre_decoded(packet),
         )
 
-    @staticmethod
-    def _build_pre_decoded(packet: dict) -> Optional[dict]:
+    def _build_pre_decoded(self, packet: dict) -> Optional[dict]:
         """Portnum + payload when the stick already decrypted locally."""
         decoded = packet.get("decoded")
         if not isinstance(decoded, dict):
@@ -237,11 +287,19 @@ class SerialCaptureSource(CaptureSource):
             logger.debug("Could not base64-decode decoded.payload", exc_info=True)
             payload = b""
 
-        return {
+        result = {
             "portnum": portnum,
             "payload": payload,
             "request_id": decoded.get("requestId", 0),
         }
+        channel_idx = packet.get("channel")
+        if channel_idx is not None:
+            channel_name = self._radio_info.get("channel_table", {}).get(
+                channel_idx
+            )
+            if channel_name:
+                result["channel_name"] = channel_name
+        return result
 
     @staticmethod
     def _reconstruct_raw(packet: dict) -> bytes:

--- a/src/decode/meshtastic_decoder.py
+++ b/src/decode/meshtastic_decoder.py
@@ -51,6 +51,7 @@ class MeshtasticDecoder:
         decrypted = False
         raw_app_payload: Optional[bytes] = None
         request_id = 0
+        remote_channel_name: Optional[str] = None
 
         if pre_decoded is not None:
             # Stick already decrypted; ciphertext discarded by protobuf oneof.
@@ -60,6 +61,7 @@ class MeshtasticDecoder:
             )
             raw_app_payload = pre_decoded.get("payload") or None
             request_id = pre_decoded.get("request_id", 0)
+            remote_channel_name = pre_decoded.get("channel_name")
             if decoded_payload is not None:
                 decrypted = True
 
@@ -181,6 +183,7 @@ class MeshtasticDecoder:
             raw_radio_packet=bytes(raw_bytes),
             decrypted=decrypted,
             matched_channel_index=matched_channel_index,
+            remote_channel_name=remote_channel_name,
             signal=signal,
             timestamp=datetime.now(timezone.utc),
         )

--- a/src/models/packet.py
+++ b/src/models/packet.py
@@ -84,6 +84,9 @@ class Packet:
     # packet. Set even when channel_hash does not match a local name+key
     # hash (remote used a different channel name, same PSK).
     matched_channel_index: Optional[int] = None
+    # Stick-local channel name when meshtastic-python decoded with its
+    # own table. packet.channel_hash may hold the stick's index, not OTA hash.
+    remote_channel_name: Optional[str] = None
 
     signal: Optional[SignalMetrics] = None
     capture_source: str = "unknown"

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -135,22 +135,118 @@ class SerialCaptureSourceDropTest(unittest.TestCase):
 class BuildPreDecodedEarlyExitTest(unittest.TestCase):
     """Early exits that must not require the meshtastic package."""
 
+    def setUp(self):
+        self.source = SerialCaptureSource(port="/dev/ttyUSB0")
+
     def test_no_decoded_key_returns_none(self):
-        self.assertIsNone(
-            SerialCaptureSource._build_pre_decoded({"raw": "aa"})
-        )
+        self.assertIsNone(self.source._build_pre_decoded({"raw": "aa"}))
 
     def test_decoded_not_a_dict_returns_none(self):
         self.assertIsNone(
-            SerialCaptureSource._build_pre_decoded({"decoded": "not-a-dict"})
+            self.source._build_pre_decoded({"decoded": "not-a-dict"})
         )
 
     def test_decoded_missing_portnum_returns_none(self):
         self.assertIsNone(
-            SerialCaptureSource._build_pre_decoded(
-                {"decoded": {"payload": "AQI="}}
-            )
+            self.source._build_pre_decoded({"decoded": {"payload": "AQI="}})
         )
+
+    def test_resolves_channel_index_to_name_via_channel_table(self):
+        self.source._radio_info["channel_table"] = {0: "LongFast", 2: "PD2EMC"}
+        pre = self.source._build_pre_decoded(
+            {
+                "decoded": {"portnum": 1, "payload": ""},
+                "channel": 2,
+            }
+        )
+        self.assertEqual(pre["channel_name"], "PD2EMC")
+
+    def test_unresolvable_channel_index_omits_channel_name(self):
+        self.source._radio_info["channel_table"] = {0: "LongFast"}
+        pre = self.source._build_pre_decoded(
+            {
+                "decoded": {"portnum": 1, "payload": ""},
+                "channel": 5,
+            }
+        )
+        self.assertIsNotNone(pre)
+        self.assertNotIn("channel_name", pre)
+
+
+class ReadChannelTableTest(unittest.TestCase):
+    def _channel(self, index, role, name):
+        from unittest.mock import MagicMock
+
+        ch = MagicMock()
+        ch.index = index
+        ch.role = role
+        ch.settings.name = name
+        return ch
+
+    def test_builds_index_to_name_map_skipping_disabled(self):
+        from meshtastic.protobuf import channel_pb2
+        from unittest.mock import MagicMock
+
+        R = channel_pb2.Channel.Role
+        channels = [
+            self._channel(0, R.PRIMARY, "Home"),
+            self._channel(1, R.SECONDARY, "BayMesh"),
+            self._channel(2, R.DISABLED, "Unused"),
+        ]
+        iface = MagicMock()
+        iface.localNode.channels = channels
+
+        table = SerialCaptureSource._read_channel_table(
+            iface, modem_preset_name="LongFast"
+        )
+        self.assertEqual(table, {0: "Home", 1: "BayMesh"})
+
+    def test_blank_primary_name_falls_back_to_modem_preset(self):
+        from meshtastic.protobuf import channel_pb2
+        from unittest.mock import MagicMock
+
+        R = channel_pb2.Channel.Role
+        channels = [self._channel(0, R.PRIMARY, "")]
+        iface = MagicMock()
+        iface.localNode.channels = channels
+
+        table = SerialCaptureSource._read_channel_table(
+            iface, modem_preset_name="LongFast"
+        )
+        self.assertEqual(table, {0: "LongFast"})
+
+    def test_blank_secondary_name_is_skipped_not_guessed(self):
+        from meshtastic.protobuf import channel_pb2
+        from unittest.mock import MagicMock
+
+        R = channel_pb2.Channel.Role
+        channels = [
+            self._channel(0, R.PRIMARY, "Home"),
+            self._channel(1, R.SECONDARY, ""),
+        ]
+        iface = MagicMock()
+        iface.localNode.channels = channels
+
+        table = SerialCaptureSource._read_channel_table(
+            iface, modem_preset_name="LongFast"
+        )
+        self.assertEqual(table, {0: "Home"})
+
+
+class ResolveChannelIndexTest(unittest.TestCase):
+    def test_finds_index_for_known_name(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB1")
+        source._radio_info["channel_table"] = {0: "LongFast", 2: "PD2EMC"}
+        self.assertEqual(source.resolve_channel_index("PD2EMC"), 2)
+
+    def test_returns_none_for_unknown_name(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB1")
+        source._radio_info["channel_table"] = {0: "LongFast"}
+        self.assertIsNone(source.resolve_channel_index("SomeOtherChannel"))
+
+    def test_returns_none_when_channel_table_never_populated(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB1")
+        self.assertIsNone(source.resolve_channel_index("LongFast"))
 
 
 class ReconstructRawTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Connect-time stick `channel_table` (index → name); blank primary falls back to modem preset name.
- `pre_decoded.channel_name` → `Packet.remote_channel_name`; Messages routes by name match or `:named:` bucket.
- `resolve_channel_index` ready for TX translation later.

Rewritten from fork `55950c8` (javastraat). **TX half deferred:** serial `send_text` + reply-through-hearing-radio need Wave B multi-serial / `f6b2bcd` first.

## Test plan
- [x] `pytest tests/test_serial_source.py` (channel table + name resolve)
- [x] ruff clean
- [ ] Optional: USB stick; locally decoded traffic files under the matching channel conversation