### PR TITLE
Serial radio handshake: real freq/SF/BW on USB packets

### DIFF
--- a/src/capture/serial_radio_handshake.py
+++ b/src/capture/serial_radio_handshake.py
@@ -1,0 +1,111 @@
+"""Connect-time LoRa / identity readout from a Meshtastic USB stick.
+
+Populates region, channel_num, modem preset (or custom SF/BW/CR), and
+primary channel name so serial packets can stamp real signal metadata.
+
+Credit: javastraat/meshpoint ``77cdaa2`` + ``dc3fc0a``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.radio.presets import get_preset
+
+logger = logging.getLogger(__name__)
+
+
+class SerialRadioHandshake:
+    """Best-effort read of ``localNode`` LoRa config after SerialInterface open."""
+
+    @staticmethod
+    def read(interface) -> dict:
+        """Region/channel/modem/name from the interface's own config.
+
+        meshtastic-python's StreamInterface already waits for config before
+        SerialInterface returns, so localConfig.lora is populated here.
+        Any field that fails to read stays None; never raises.
+        """
+        info: dict = {
+            "region": None,
+            "channel_num": None,
+            "short_name": None,
+            "long_name": None,
+            "modem_preset": None,
+            "use_preset": True,
+            "spreading_factor": None,
+            "bandwidth_khz": None,
+            "coding_rate": None,
+            "channel_name": None,
+            "frequency_offset": 0.0,
+            "override_frequency": 0.0,
+            "channel_table": {},
+        }
+        try:
+            from meshtastic.protobuf import config_pb2
+
+            lora = interface.localNode.localConfig.lora
+            info["channel_num"] = int(lora.channel_num)
+            info["region"] = config_pb2.Config.LoRaConfig.RegionCode.Name(
+                lora.region
+            )
+            info["use_preset"] = bool(lora.use_preset)
+            info["frequency_offset"] = float(lora.frequency_offset)
+            info["override_frequency"] = float(lora.override_frequency)
+            if lora.use_preset:
+                preset_name = config_pb2.Config.LoRaConfig.ModemPreset.Name(
+                    lora.modem_preset,
+                )
+                info["modem_preset"] = preset_name
+                preset = get_preset(preset_name)
+                if preset:
+                    info["spreading_factor"] = preset.spreading_factor
+                    info["bandwidth_khz"] = preset.bandwidth_khz
+                    info["coding_rate"] = preset.coding_rate
+            else:
+                info["modem_preset"] = "CUSTOM"
+                if lora.spread_factor:
+                    info["spreading_factor"] = int(lora.spread_factor)
+                if lora.bandwidth:
+                    info["bandwidth_khz"] = float(lora.bandwidth)
+                if lora.coding_rate:
+                    info["coding_rate"] = f"4/{int(lora.coding_rate)}"
+        except Exception:
+            logger.debug(
+                "Could not read LoRa config from serial interface",
+                exc_info=True,
+            )
+        try:
+            info["short_name"] = interface.getShortName()
+            info["long_name"] = interface.getLongName()
+        except Exception:
+            logger.debug(
+                "Could not read node identity from serial interface",
+                exc_info=True,
+            )
+        try:
+            info["channel_name"] = SerialRadioHandshake.read_primary_channel_name(
+                interface
+            )
+        except Exception:
+            logger.debug(
+                "Could not read primary channel name from serial interface",
+                exc_info=True,
+            )
+        return info
+
+    @staticmethod
+    def read_primary_channel_name(interface) -> Optional[str]:
+        """Primary channel settings.name, or None if no primary channel.
+
+        Empty string means a blank name (firmware falls back to preset
+        display string for slot hashing). None means no primary found.
+        """
+        from meshtastic.protobuf import channel_pb2
+
+        channels = getattr(interface.localNode, "channels", None) or []
+        for ch in channels:
+            if ch.role == channel_pb2.Channel.Role.PRIMARY:
+                return ch.settings.name
+        return None

--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -7,8 +7,10 @@ from datetime import datetime, timezone
 from typing import AsyncIterator, Optional
 
 from src.capture.base import CaptureSource
+from src.capture.serial_radio_handshake import SerialRadioHandshake
 from src.models.packet import RawCapture
 from src.models.signal import SignalMetrics
+from src.radio.channel_frequency import resolve_frequency_mhz
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +98,10 @@ class SerialCaptureSource(CaptureSource):
     def is_running(self) -> bool:
         return self._running
 
+    def get_radio_info(self) -> dict:
+        """Connect-time LoRa/identity snapshot (copy)."""
+        return dict(self._radio_info)
+
     def resolve_channel_index(self, name: str) -> Optional[int]:
         """This stick's channel-table index for ``name``, or None."""
         table = self._radio_info.get("channel_table") or {}
@@ -118,8 +124,11 @@ class SerialCaptureSource(CaptureSource):
 
             own_node = SerialSelfOriginFilter.read_own_node_num(self._interface)
             self._self_origin.set_own_node_num(own_node)
+            self._radio_info = SerialRadioHandshake.read(self._interface)
             try:
-                modem_preset = self._read_modem_preset_name(self._interface)
+                modem_preset = self._radio_info.get("modem_preset")
+                if modem_preset == "CUSTOM":
+                    modem_preset = None
                 self._radio_info["channel_table"] = self._read_channel_table(
                     self._interface, modem_preset
                 )
@@ -132,16 +141,35 @@ class SerialCaptureSource(CaptureSource):
 
             pub.subscribe(self._on_receive, "meshtastic.receive")
             self._running = True
+            region = self._radio_info.get("region")
+            freq = resolve_frequency_mhz(
+                region=region,
+                channel_num=self._radio_info.get("channel_num"),
+                bandwidth_khz=self._radio_info.get("bandwidth_khz") or 250.0,
+                channel_name=self._radio_info.get("channel_name"),
+                modem_preset=self._radio_info.get("modem_preset"),
+                use_preset=self._radio_info.get("use_preset", True),
+                frequency_offset=self._radio_info.get("frequency_offset") or 0.0,
+                override_frequency=self._radio_info.get("override_frequency")
+                or 0.0,
+            )
             if own_node is not None:
                 logger.info(
-                    "Serial capture started on %s (own_node=%08x)",
+                    "Serial capture started on %s (own_node=%08x region=%s "
+                    "freq=%.3f SF%s BW%s)",
                     self._port or "auto-detect",
                     own_node,
+                    region or "?",
+                    freq,
+                    self._radio_info.get("spreading_factor") or "?",
+                    self._radio_info.get("bandwidth_khz") or "?",
                 )
             else:
                 logger.info(
-                    "Serial capture started on %s",
+                    "Serial capture started on %s (region=%s freq=%.3f)",
                     self._port or "auto-detect",
+                    region or "?",
+                    freq,
                 )
         except ImportError:
             logger.error(
@@ -152,18 +180,6 @@ class SerialCaptureSource(CaptureSource):
         except Exception:
             logger.exception("Failed to open serial interface")
             raise
-
-    @staticmethod
-    def _read_modem_preset_name(interface) -> Optional[str]:
-        try:
-            from meshtastic.protobuf import config_pb2
-
-            lora = interface.localNode.localConfig.lora
-            if not lora.use_preset:
-                return None
-            return config_pb2.Config.LoRaConfig.ModemPreset.Name(lora.modem_preset)
-        except Exception:
-            return None
 
     @staticmethod
     def _read_channel_table(
@@ -245,12 +261,24 @@ class SerialCaptureSource(CaptureSource):
         if not raw_bytes:
             return None
 
+        radio = self._radio_info
+        # Fall back to LongFast SF/BW only when handshake left them unset.
+        bandwidth_khz = radio.get("bandwidth_khz") or 250.0
         signal = SignalMetrics(
             rssi=float(packet.get("rxRssi", packet.get("rssi", -100))),
             snr=float(packet.get("rxSnr", packet.get("snr", 0))),
-            frequency_mhz=906.875,
-            spreading_factor=11,
-            bandwidth_khz=250.0,
+            frequency_mhz=resolve_frequency_mhz(
+                region=radio.get("region"),
+                channel_num=radio.get("channel_num"),
+                bandwidth_khz=bandwidth_khz,
+                channel_name=radio.get("channel_name"),
+                modem_preset=radio.get("modem_preset"),
+                use_preset=radio.get("use_preset", True),
+                frequency_offset=radio.get("frequency_offset") or 0.0,
+                override_frequency=radio.get("override_frequency") or 0.0,
+            ),
+            spreading_factor=radio.get("spreading_factor") or 11,
+            bandwidth_khz=float(bandwidth_khz),
         )
 
         return RawCapture(

--- a/src/radio/channel_frequency.py
+++ b/src/radio/channel_frequency.py
@@ -1,0 +1,110 @@
+"""Meshtastic channel-to-frequency resolution for serial capture.
+
+Replicates the frequency computation in meshtastic firmware
+``RadioInterface::applyModemConfig`` so USB-stick packets can carry
+the stick's real center frequency instead of a hardcoded guess.
+
+Only PROFILE_STD / PROFILE_EU868 regions (spacing=0, padding=0) are
+modelled: the same set already used elsewhere in this codebase.
+Unsupported regions resolve to 0.0 rather than a wrong number.
+
+Credit: javastraat/meshpoint ``77cdaa2`` + ``dc3fc0a``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# (freqStart, freqEnd) in MHz from firmware regions[] (spacing=0, padding=0).
+_REGION_BAND_MHZ: dict[str, tuple[float, float]] = {
+    "US": (902.0, 928.0),
+    "EU_433": (433.0, 434.0),
+    "EU_868": (869.4, 869.65),
+    "ANZ": (915.0, 928.0),
+    "IN": (865.0, 867.0),
+    "KR": (920.0, 923.0),
+    "SG_923": (917.0, 925.0),
+}
+
+# Firmware DisplayFormatters::getModemPresetDisplayName (useShortName=false).
+# Kept separate from src.radio.presets UI labels (e.g. LONG_MODERATE -> LongMod).
+_PRESET_HASH_NAME: dict[str, str] = {
+    "SHORT_TURBO": "ShortTurbo",
+    "SHORT_SLOW": "ShortSlow",
+    "SHORT_FAST": "ShortFast",
+    "MEDIUM_SLOW": "MediumSlow",
+    "MEDIUM_FAST": "MediumFast",
+    "LONG_SLOW": "LongSlow",
+    "LONG_FAST": "LongFast",
+    "LONG_TURBO": "LongTurbo",
+    "LONG_MODERATE": "LongMod",
+    "LITE_FAST": "LiteFast",
+    "LITE_SLOW": "LiteSlow",
+    "NARROW_FAST": "NarrowFast",
+    "NARROW_SLOW": "NarrowSlow",
+    "TINY_FAST": "TinyFast",
+    "TINY_SLOW": "TinySlow",
+}
+_PRESET_HASH_NAME_FALLBACK = "Invalid"
+_CUSTOM_HASH_NAME = "Custom"
+
+
+def _djb2(text: str) -> int:
+    """djb2 matching firmware ``hash()``: seed 5381, uint32 wrap."""
+    h = 5381
+    for byte in text.encode("utf-8"):
+        h = ((h << 5) + h + byte) & 0xFFFFFFFF
+    return h
+
+
+def _preset_hash_name(modem_preset: Optional[str], use_preset: bool) -> str:
+    if not use_preset:
+        return _CUSTOM_HASH_NAME
+    return _PRESET_HASH_NAME.get(modem_preset or "", _PRESET_HASH_NAME_FALLBACK)
+
+
+def resolve_frequency_mhz(
+    *,
+    region: Optional[str],
+    channel_num: Optional[int],
+    bandwidth_khz: Optional[float],
+    channel_name: Optional[str] = None,
+    modem_preset: Optional[str] = None,
+    use_preset: bool = True,
+    frequency_offset: float = 0.0,
+    override_frequency: float = 0.0,
+) -> float:
+    """Operating frequency matching firmware slot selection.
+
+    ``channel_num`` 0 means hash-derived slot; positive N is explicit
+    1-based slot N. Returns 0.0 when there is not enough information.
+    """
+    if override_frequency:
+        return round(override_frequency + frequency_offset, 4)
+
+    if not region or not bandwidth_khz:
+        return 0.0
+    band = _REGION_BAND_MHZ.get(region)
+    if band is None:
+        return 0.0
+
+    freq_start, freq_end = band
+    freq_slot_width = bandwidth_khz / 1000.0
+    if freq_slot_width <= 0:
+        return 0.0
+    num_slots = round((freq_end - freq_start) / freq_slot_width)
+    if num_slots <= 0:
+        return 0.0
+
+    if channel_num:
+        slot = channel_num - 1
+        if slot >= num_slots:
+            return 0.0
+    else:
+        name = (channel_name or "").strip()
+        if not name:
+            name = _preset_hash_name(modem_preset, use_preset)
+        slot = _djb2(name) % num_slots
+
+    freq = freq_start + (bandwidth_khz / 2000.0) + slot * freq_slot_width
+    return round(freq + frequency_offset, 4)

--- a/tests/test_channel_frequency.py
+++ b/tests/test_channel_frequency.py
@@ -1,0 +1,172 @@
+"""Tests for src.radio.channel_frequency (Meshtastic channel->frequency).
+
+Pure Python, no meshtastic/protobuf dependency (unlike most of the
+other serial-capture-adjacent tests in this suite), so this runs on a
+bare Mac python3. Every expected value here is either cross-checked
+against a real device's observed frequency (EU_433 default channel ->
+433.875 MHz) or hand-derived from meshtastic/firmware's
+src/mesh/RadioInterface.cpp formula, read directly from a local
+firmware source checkout.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.radio.channel_frequency import _djb2, resolve_frequency_mhz
+
+
+class Djb2Test(unittest.TestCase):
+    def test_matches_known_values(self):
+        # djb2("") = 5381 (the seed, no bytes folded in).
+        self.assertEqual(_djb2(""), 5381)
+
+    def test_is_deterministic(self):
+        self.assertEqual(_djb2("LongFast"), _djb2("LongFast"))
+
+    def test_different_strings_differ(self):
+        self.assertNotEqual(_djb2("LongFast"), _djb2("LongSlow"))
+
+    def test_stays_within_32_bits(self):
+        # A long input must not overflow past uint32 wraparound.
+        self.assertLess(_djb2("x" * 1000), 2**32)
+
+
+class ResolveFrequencyDefaultChannelTest(unittest.TestCase):
+    """channel_num=0: hash-derived slot from the primary channel name."""
+
+    def test_eu433_blank_channel_name_falls_back_to_preset_display_name(self):
+        # Reproduces a real device's observed frequency exactly: blank
+        # primary channel name (the common stock case) falls back to
+        # the LongFast preset's firmware display string for hashing.
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=0, bandwidth_khz=250,
+            channel_name="", modem_preset="LONG_FAST", use_preset=True,
+        )
+        self.assertEqual(freq, 433.875)
+
+    def test_eu433_none_channel_name_same_as_blank(self):
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=0, bandwidth_khz=250,
+            channel_name=None, modem_preset="LONG_FAST", use_preset=True,
+        )
+        self.assertEqual(freq, 433.875)
+
+    def test_eu433_custom_channel_name_changes_the_slot(self):
+        # A real (non-blank) channel name is hashed directly -- a
+        # different name can land on a different one of the 4 slots.
+        freq_custom = resolve_frequency_mhz(
+            region="EU_433", channel_num=0, bandwidth_khz=250,
+            channel_name="MySecretChannel",
+        )
+        # Not asserting a specific value (that depends on the hash of
+        # an arbitrary string) -- just that a real channel name is
+        # actually used rather than always falling back to the preset.
+        self.assertIn(freq_custom, (433.125, 433.375, 433.625, 433.875))
+
+    def test_eu868_single_slot_is_independent_of_channel_name(self):
+        # EU_868's band (869.4-869.65 MHz) only fits one 250kHz slot,
+        # so the default is deterministic regardless of channel name --
+        # this is why a LongFast channel on 868 and a LongFast channel
+        # on 433 (same name) never collide: different regions, and 868
+        # never even reaches the hash step.
+        for name in ("", "LongFast", "AnythingAtAll", "custom-mesh"):
+            freq = resolve_frequency_mhz(
+                region="EU_868", channel_num=0, bandwidth_khz=250,
+                channel_name=name,
+            )
+            self.assertEqual(freq, 869.525, f"failed for channel_name={name!r}")
+
+    def test_use_preset_false_hashes_custom_literal(self):
+        # use_preset=False (fully custom SF/BW/CR, no named preset) ->
+        # firmware hashes the literal string "Custom" when the channel
+        # name is also blank.
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=0, bandwidth_khz=250,
+            channel_name="", use_preset=False,
+        )
+        self.assertIn(freq, (433.125, 433.375, 433.625, 433.875))
+
+    def test_long_moderate_preset_uses_firmware_short_string_not_ui_label(self):
+        # Regression guard: firmware's hash string for LONG_MODERATE is
+        # "LongMod", NOT "LongModerate" (this codebase's own UI label
+        # in src/radio/presets.py) -- using the wrong one would
+        # silently compute a different (wrong) slot.
+        from src.radio.channel_frequency import _preset_hash_name
+        self.assertEqual(_preset_hash_name("LONG_MODERATE", True), "LongMod")
+
+    def test_unrecognized_preset_falls_back_to_invalid_literal(self):
+        from src.radio.channel_frequency import _preset_hash_name
+        self.assertEqual(_preset_hash_name("VERY_LONG_SLOW", True), "Invalid")
+        self.assertEqual(_preset_hash_name(None, True), "Invalid")
+
+
+class ResolveFrequencyExplicitChannelTest(unittest.TestCase):
+    """channel_num > 0: explicit 1-based slot, no hash needed."""
+
+    def test_channel_num_one_is_slot_zero(self):
+        freq = resolve_frequency_mhz(region="EU_433", channel_num=1, bandwidth_khz=250)
+        self.assertEqual(freq, 433.125)
+
+    def test_channel_num_four_is_slot_three(self):
+        freq = resolve_frequency_mhz(region="EU_433", channel_num=4, bandwidth_khz=250)
+        self.assertEqual(freq, 433.875)
+
+    def test_channel_num_beyond_region_slot_count_is_unknown_not_a_guess(self):
+        # Firmware itself rejects a channel_num above the region's
+        # slot count at config-set time -- a real device never
+        # reports one out of range. EU_868 only has 1 slot, so
+        # channel_num=5 (slot 4) must not compute an out-of-band
+        # number.
+        freq = resolve_frequency_mhz(region="EU_868", channel_num=5, bandwidth_khz=250)
+        self.assertEqual(freq, 0.0)
+
+    def test_explicit_channel_ignores_channel_name(self):
+        freq_a = resolve_frequency_mhz(
+            region="EU_433", channel_num=2, bandwidth_khz=250, channel_name="Alpha",
+        )
+        freq_b = resolve_frequency_mhz(
+            region="EU_433", channel_num=2, bandwidth_khz=250, channel_name="Bravo",
+        )
+        self.assertEqual(freq_a, freq_b)
+
+
+class ResolveFrequencyEdgeCaseTest(unittest.TestCase):
+    def test_override_frequency_wins_outright(self):
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=0, bandwidth_khz=250,
+            override_frequency=433.5, frequency_offset=0.1,
+        )
+        self.assertEqual(freq, 433.6)
+
+    def test_frequency_offset_applied_to_computed_frequency(self):
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=1, bandwidth_khz=250, frequency_offset=0.05,
+        )
+        self.assertEqual(freq, 433.175)
+
+    def test_missing_region_yields_unknown(self):
+        self.assertEqual(
+            resolve_frequency_mhz(region=None, channel_num=0, bandwidth_khz=250), 0.0,
+        )
+
+    def test_missing_bandwidth_yields_unknown(self):
+        self.assertEqual(
+            resolve_frequency_mhz(region="EU_433", channel_num=0, bandwidth_khz=None), 0.0,
+        )
+
+    def test_unsupported_region_yields_unknown_not_a_guess(self):
+        # EU_866 uses PROFILE_LITE (nonzero spacing/padding), not
+        # modelled by this simplified resolver.
+        self.assertEqual(
+            resolve_frequency_mhz(region="EU_866", channel_num=0, bandwidth_khz=250), 0.0,
+        )
+
+    def test_zero_bandwidth_does_not_divide_by_zero(self):
+        self.assertEqual(
+            resolve_frequency_mhz(region="EU_433", channel_num=0, bandwidth_khz=0), 0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serial_radio_handshake.py
+++ b/tests/test_serial_radio_handshake.py
@@ -1,0 +1,159 @@
+"""Tests for SerialRadioHandshake connect-time LoRa readout.
+
+Needs the real ``meshtastic`` package (protobuf enums). Same convention
+as other serial-adjacent tests.
+
+Credit: javastraat/meshpoint ``77cdaa2`` + ``dc3fc0a``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from meshtastic.protobuf import channel_pb2, config_pb2  # noqa: F401
+
+from src.capture.serial_radio_handshake import SerialRadioHandshake
+from src.capture.serial_source import SerialCaptureSource
+from src.radio.channel_frequency import resolve_frequency_mhz
+
+
+def _mock_primary_channel(name: str):
+    ch = MagicMock()
+    ch.role = channel_pb2.Channel.Role.PRIMARY
+    ch.settings.name = name
+    return ch
+
+
+class ReadRadioInfoLongFastPresetTest(unittest.TestCase):
+    def test_eu433_longfast_preset(self):
+        iface = MagicMock()
+        iface.localNode.localConfig.lora.channel_num = 0
+        iface.localNode.localConfig.lora.region = 2  # EU_433
+        iface.localNode.localConfig.lora.use_preset = True
+        iface.localNode.localConfig.lora.modem_preset = 0  # LONG_FAST
+        iface.localNode.localConfig.lora.frequency_offset = 0.0
+        iface.localNode.localConfig.lora.override_frequency = 0.0
+        iface.localNode.channels = [_mock_primary_channel("")]
+        iface.getShortName.return_value = "EMC3"
+        iface.getLongName.return_value = "Meshpoint433"
+
+        info = SerialRadioHandshake.read(iface)
+
+        self.assertEqual(info["region"], "EU_433")
+        self.assertEqual(info["channel_num"], 0)
+        self.assertEqual(info["modem_preset"], "LONG_FAST")
+        self.assertTrue(info["use_preset"])
+        self.assertEqual(info["channel_name"], "")
+        self.assertEqual(info["spreading_factor"], 11)
+        self.assertEqual(info["bandwidth_khz"], 250)
+        self.assertEqual(info["coding_rate"], "4/5")
+        self.assertEqual(info["short_name"], "EMC3")
+        self.assertEqual(info["long_name"], "Meshpoint433")
+
+    def test_reads_primary_channel_name_when_set(self):
+        iface = MagicMock()
+        iface.localNode.channels = [
+            _mock_primary_channel("MyCustomChannel"),
+        ]
+        name = SerialRadioHandshake.read_primary_channel_name(iface)
+        self.assertEqual(name, "MyCustomChannel")
+
+    def test_default_frequency_matches_eu433_preset_default_channel(self):
+        freq = resolve_frequency_mhz(
+            region="EU_433",
+            channel_num=0,
+            bandwidth_khz=250,
+            channel_name="",
+            modem_preset="LONG_FAST",
+            use_preset=True,
+        )
+        self.assertEqual(freq, 433.875)
+
+    def test_default_frequency_matches_eu868_preset_default_channel(self):
+        freq = resolve_frequency_mhz(
+            region="EU_868",
+            channel_num=0,
+            bandwidth_khz=250,
+            channel_name="AnythingAtAll",
+            modem_preset="LONG_FAST",
+        )
+        self.assertEqual(freq, 869.525)
+
+
+class ReadRadioInfoCustomConfigTest(unittest.TestCase):
+    def test_custom_config_reads_raw_fields(self):
+        iface = MagicMock()
+        iface.localNode.localConfig.lora.channel_num = 3
+        iface.localNode.localConfig.lora.region = 3  # EU_868
+        iface.localNode.localConfig.lora.use_preset = False
+        iface.localNode.localConfig.lora.spread_factor = 9
+        iface.localNode.localConfig.lora.bandwidth = 125
+        iface.localNode.localConfig.lora.coding_rate = 6
+        iface.localNode.localConfig.lora.frequency_offset = 0.0
+        iface.localNode.localConfig.lora.override_frequency = 0.0
+        iface.localNode.channels = [_mock_primary_channel("")]
+        iface.getShortName.return_value = "CUST"
+        iface.getLongName.return_value = "CustomNode"
+
+        info = SerialRadioHandshake.read(iface)
+
+        self.assertEqual(info["modem_preset"], "CUSTOM")
+        self.assertFalse(info["use_preset"])
+        self.assertEqual(info["spreading_factor"], 9)
+        self.assertEqual(info["bandwidth_khz"], 125.0)
+        self.assertEqual(info["coding_rate"], "4/6")
+
+    def test_non_default_channel_num_uses_explicit_slot(self):
+        freq = resolve_frequency_mhz(
+            region="EU_433", channel_num=3, bandwidth_khz=250
+        )
+        self.assertEqual(freq, 433.625)
+
+
+class ReadRadioInfoFailureIsolationTest(unittest.TestCase):
+    def test_broken_interface_returns_none_filled_dict_not_raise(self):
+        iface = MagicMock()
+        del iface.localNode
+        iface.getShortName.side_effect = Exception("boom")
+
+        info = SerialRadioHandshake.read(iface)
+
+        self.assertIsNone(info["region"])
+        self.assertIsNone(info["channel_num"])
+        self.assertIsNone(info["short_name"])
+
+
+class PacketSignalFromHandshakeTest(unittest.TestCase):
+    def test_packet_uses_handshake_frequency_not_hardcoded_us(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._radio_info = {
+            "region": "EU_868",
+            "channel_num": 0,
+            "bandwidth_khz": 250.0,
+            "spreading_factor": 11,
+            "channel_name": "",
+            "modem_preset": "LONG_FAST",
+            "use_preset": True,
+            "frequency_offset": 0.0,
+            "override_frequency": 0.0,
+            "channel_table": {},
+        }
+        result = source._packet_to_raw_capture(
+            {
+                "from": 0xAABBCCDD,
+                "to": 0xFFFFFFFF,
+                "id": 1,
+                "raw": b"\x00" * 16,
+                "rxRssi": -90,
+                "rxSnr": 5.0,
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.signal.frequency_mhz, 869.525)
+        self.assertEqual(result.signal.spreading_factor, 11)
+        self.assertEqual(result.signal.bandwidth_khz, 250.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Port Wave B1 from javastraat/meshpoint (`77cdaa2` + `dc3fc0a`): connect-time LoRa handshake + firmware-matched frequency resolver
- Serial packets no longer stamp hardcoded `906.875` / SF11 / BW250; they use the stick region, channel slot, and modem preset (or custom SF/BW/CR)
- New `SerialRadioHandshake` + `resolve_frequency_mhz`; `get_radio_info()` on the serial source for later UI/API use

## Credit
Rewrite against current `feat/v0.7.8` serial capture (A1 + pre_decoded + channel table). Co-authored with Albert Einstein (`javastraat@hotmail.com`).

## Test plan
- [x] `pytest tests/test_channel_frequency.py tests/test_serial_radio_handshake.py tests/test_serial_source.py` (54 passed)
- [x] ruff clean on touched files
- [ ] Optional: on RAK V2 with Heltec serial, confirm journal `Serial capture started ... freq=` matches stick region and SQLite serial rows are not all 906.875