### PR TITLE
Serial send route: reply via stick + name-matched channel

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -680,6 +680,8 @@ def _build_tx_service(
         radio_config=config.radio,
         primary_channel_name=config.meshtastic.primary_channel_name,
         device_id=config.device.device_id,
+        node_repo=coord.node_repo,
+        serial_sources=_find_serial_sources(coord),
     )
     logger.info(
         "Transmit service ready: MT=%s MC=%s",
@@ -833,6 +835,17 @@ def _find_meshcore_source(coord: PipelineCoordinator):
         if src.name == "meshcore_usb":
             return src
     return None
+
+
+def _find_serial_sources(coord: PipelineCoordinator) -> list:
+    """Meshtastic USB serial capture sources (for reply routing)."""
+    from src.capture.serial_source import SerialCaptureSource
+
+    return [
+        src
+        for src in coord.capture_coordinator._sources
+        if isinstance(src, SerialCaptureSource)
+    ]
 
 
 async def _reapply_companion_name(meshcore_tx, config: AppConfig) -> None:

--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -181,12 +181,24 @@ class SerialCaptureSource(CaptureSource):
             logger.exception("Failed to open serial interface")
             raise
 
+    @property
+    def connected(self) -> bool:
+        """True while the serial interface is open and capture is running."""
+        return self._running and self._interface is not None
+
     @staticmethod
     def _read_channel_table(
         interface, modem_preset_name: Optional[str] = None
     ) -> dict:
-        """Stick channel-table index -> name (for locally decoded packets)."""
+        """Stick channel-table index -> name (for locally decoded packets).
+
+        Blank primary names fall back to the modem preset *display* name
+        (e.g. ``LongFast``), matching Meshpoint's primary-channel naming
+        and firmware ``Channels::getName()`` so TX can translate by name.
+        """
         from meshtastic.protobuf import channel_pb2
+
+        from src.radio.presets import get_preset
 
         table: dict[int, str] = {}
         channels = getattr(interface.localNode, "channels", None) or []
@@ -195,10 +207,49 @@ class SerialCaptureSource(CaptureSource):
                 continue
             name = ch.settings.name
             if not name and ch.role == channel_pb2.Channel.Role.PRIMARY:
-                name = modem_preset_name
+                preset = get_preset(modem_preset_name) if modem_preset_name else None
+                name = preset.display_name if preset else modem_preset_name
             if name:
                 table[ch.index] = name
         return table
+
+    def send_text(
+        self,
+        text: str,
+        destination: int | str,
+        channel_index: int = 0,
+        want_ack: bool = False,
+    ) -> dict:
+        """Send text via this stick's meshtastic-python interface.
+
+        Returns a plain dict (not ``SendResult``) so capture stays free of
+        transmit-layer types. Credit: javastraat/meshpoint ``f6b2bcd``.
+        """
+        iface = self._interface
+        if iface is None or not self.connected:
+            return {"success": False, "error": "Not connected", "packet_id": ""}
+        try:
+            sent = iface.sendText(
+                text,
+                destinationId=destination,
+                wantAck=want_ack,
+                channelIndex=channel_index,
+            )
+            packet_id = (
+                f"{sent.id:08x}"
+                if sent is not None and hasattr(sent, "id")
+                else ""
+            )
+            logger.info(
+                "%s: text message sent (dest=%s, id=%s)",
+                self.name,
+                destination,
+                packet_id or "unknown",
+            )
+            return {"success": True, "error": "", "packet_id": packet_id}
+        except Exception as exc:
+            logger.exception("%s: send_text failed", self.name)
+            return {"success": False, "error": str(exc), "packet_id": ""}
 
     async def stop(self) -> None:
         self._running = False

--- a/src/storage/node_repository.py
+++ b/src/storage/node_repository.py
@@ -99,6 +99,19 @@ class NodeRepository:
         )
         return [self._row_to_node(r) for r in rows]
 
+    async def get_latest_capture_source(self, source_id: str) -> Optional[str]:
+        """Capture source that most recently heard a packet from *source_id*.
+
+        Used to route outbound replies through the same radio that can
+        reach the contact. Credit: javastraat/meshpoint ``f6b2bcd``.
+        """
+        row = await self._db.fetch_one(
+            "SELECT capture_source FROM packets WHERE source_id = ? "
+            "ORDER BY timestamp DESC LIMIT 1",
+            (source_id,),
+        )
+        return row["capture_source"] if row else None
+
     async def get_all_with_signal(self, limit: int = 500) -> list[dict]:
         """Return nodes with latest signal and telemetry from joined tables."""
         rows = await self._db.fetch_all(

--- a/src/transmit/tx_service.py
+++ b/src/transmit/tx_service.py
@@ -72,6 +72,8 @@ class TxService:
         primary_channel_name: str = "",
         device_id: Optional[str] = None,
         persist_derived_node_id: bool = True,
+        node_repo=None,
+        serial_sources: Optional[list] = None,
     ):
         self._wrapper = wrapper
         self._crypto = crypto
@@ -90,6 +92,10 @@ class TxService:
             self._persist_derived_node_id_if_needed()
         self._device_metrics_provider = None
         self._local_stats_provider = None
+        # Optional: route Meshtastic DMs via the USB stick that last
+        # heard the contact (fork f6b2bcd / 55950c8).
+        self._node_repo = node_repo
+        self._serial_sources = serial_sources or []
 
     @property
     def meshtastic_enabled(self) -> bool:
@@ -274,7 +280,44 @@ class TxService:
         want_ack: bool,
         echo_hash: int | None = None,
     ) -> SendResult:
-        """Build and transmit a Meshtastic packet via the SX1261."""
+        """Transmit via USB stick when that stick last heard the dest, else SX1261."""
+        dest_int = self._resolve_destination(destination, Protocol.MESHTASTIC)
+
+        if (
+            self._config is not None
+            and self._config.enabled
+            and dest_int != BROADCAST_ADDR_MT
+        ):
+            serial_source = await self._resolve_serial_send_source(dest_int)
+            if serial_source is not None:
+                channel_name = self._channel_name_for_index(channel)
+                stick_channel_index = serial_source.resolve_channel_index(
+                    channel_name
+                )
+                if stick_channel_index is None:
+                    return SendResult(
+                        success=False,
+                        protocol="meshtastic",
+                        error=(
+                            f"{serial_source.name} has no channel named "
+                            f"'{channel_name}' -- refusing to send on a "
+                            "possibly-wrong channel"
+                        ),
+                    )
+                result = serial_source.send_text(
+                    text,
+                    dest_int,
+                    channel_index=stick_channel_index,
+                    want_ack=want_ack,
+                )
+                return SendResult(
+                    success=result["success"],
+                    protocol="meshtastic",
+                    packet_id=result["packet_id"],
+                    timestamp=time.time(),
+                    error=result["error"],
+                )
+
         if not self.meshtastic_enabled:
             return SendResult(
                 success=False,
@@ -290,7 +333,6 @@ class TxService:
                 error="Packet builder unavailable",
             )
 
-        dest_int = self._resolve_destination(destination, Protocol.MESHTASTIC)
         packet_id = self._next_packet_id()
         channel_hash, channel_key = self._resolve_channel(channel)
         if echo_hash is not None:
@@ -960,6 +1002,40 @@ class TxService:
             value = secrets.randbits(32)
             if value not in RESERVED_NODE_IDS:
                 return value
+
+    async def _resolve_serial_send_source(self, dest_int: int):
+        """USB stick that last heard *dest_int*, if any and still connected.
+
+        Credit: javastraat/meshpoint ``f6b2bcd``.
+        """
+        if not self._node_repo or not self._serial_sources:
+            return None
+        try:
+            lookup_id = f"{dest_int:08x}"
+            source_name = await self._node_repo.get_latest_capture_source(
+                lookup_id
+            )
+        except Exception:
+            logger.debug("Serial send-source lookup failed", exc_info=True)
+            return None
+        if not source_name:
+            return None
+        for src in self._serial_sources:
+            if src.name == source_name and getattr(src, "connected", False):
+                return src
+        return None
+
+    def _channel_name_for_index(self, channel: int) -> str:
+        """Meshpoint channel name for a dashboard channel index.
+
+        Used to map to a USB stick's independently numbered channel table.
+        Credit: javastraat/meshpoint ``55950c8``.
+        """
+        if channel != 0 and self._crypto is not None:
+            channel_keys = list(self._crypto._keys.items())
+            if channel - 1 < len(channel_keys):
+                return channel_keys[channel - 1][0]
+        return self._primary_channel_name or self._get_preset_name()
 
     def _resolve_channel(self, channel: int) -> tuple[int, bytes | None]:
         """Resolve channel index to (hash, encryption_key).

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -211,7 +211,7 @@ class ReadChannelTableTest(unittest.TestCase):
         iface.localNode.channels = channels
 
         table = SerialCaptureSource._read_channel_table(
-            iface, modem_preset_name="LongFast"
+            iface, modem_preset_name="LONG_FAST"
         )
         self.assertEqual(table, {0: "LongFast"})
 

--- a/tests/test_tx_service.py
+++ b/tests/test_tx_service.py
@@ -295,6 +295,72 @@ class TestEchoHashOverride(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kwargs["channel_key"], b"the-real-channel-key")
 
 
+class TestSerialSendChannelTranslation(unittest.IsolatedAsyncioTestCase):
+    """Reply via USB stick: translate Meshpoint channel index by name."""
+
+    def _build_tx_service(self, primary_name="LongFast", channel_keys=None):
+        tx = TxService(persist_derived_node_id=False)
+        tx._config = Mock(enabled=True)
+        tx._primary_channel_name = primary_name
+        crypto = Mock()
+        crypto._keys = dict(channel_keys or {})
+        tx._crypto = crypto
+        return tx
+
+    async def test_translates_name_and_sends_on_sticks_own_index(self):
+        tx = self._build_tx_service(channel_keys={"BayMesh": b"key"})
+        serial_source = Mock()
+        serial_source.name = "serial"
+        serial_source.resolve_channel_index = Mock(return_value=5)
+        serial_source.send_text = Mock(
+            return_value={"success": True, "error": "", "packet_id": "abc"}
+        )
+        tx._resolve_serial_send_source = AsyncMock(return_value=serial_source)
+
+        result = await tx._send_meshtastic(
+            "hi", 0x11223344, channel=1, want_ack=False, echo_hash=None,
+        )
+
+        serial_source.resolve_channel_index.assert_called_once_with("BayMesh")
+        serial_source.send_text.assert_called_once_with(
+            "hi", 0x11223344, channel_index=5, want_ack=False,
+        )
+        self.assertTrue(result.success)
+
+    async def test_refuses_to_send_when_stick_lacks_the_channel(self):
+        tx = self._build_tx_service(channel_keys={"BayMesh": b"key"})
+        serial_source = Mock()
+        serial_source.name = "serial"
+        serial_source.resolve_channel_index = Mock(return_value=None)
+        serial_source.send_text = Mock()
+        tx._resolve_serial_send_source = AsyncMock(return_value=serial_source)
+
+        result = await tx._send_meshtastic(
+            "hi", 0x11223344, channel=1, want_ack=False, echo_hash=None,
+        )
+
+        serial_source.send_text.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertIn("BayMesh", result.error)
+        self.assertIn("serial", result.error)
+
+    async def test_primary_channel_translates_via_primary_name(self):
+        tx = self._build_tx_service(primary_name="Home")
+        serial_source = Mock()
+        serial_source.name = "serial"
+        serial_source.resolve_channel_index = Mock(return_value=0)
+        serial_source.send_text = Mock(
+            return_value={"success": True, "error": "", "packet_id": ""}
+        )
+        tx._resolve_serial_send_source = AsyncMock(return_value=serial_source)
+
+        await tx._send_meshtastic(
+            "hi", 0x11223344, channel=0, want_ack=False, echo_hash=None,
+        )
+
+        serial_source.resolve_channel_index.assert_called_once_with("Home")
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary
- Wave B / A8 TX from javastraat/meshpoint (`f6b2bcd` + `55950c8` TX half)
- DMs to a node last heard on USB serial go out via that stick (`send_text`), not the concentrator
- Channel index is translated by **name** to the stick's own table; missing name refuses the send
- Blank primary channel table entries use preset display name (`LongFast`) so names match Meshpoint
- `NodeRepository.get_latest_capture_source` + `TxService` serial_sources wiring

## Credit
Rewrite against current `feat/v0.7.8`. Co-authored with Albert Einstein (`javastraat@hotmail.com`).

## Test plan
- [x] `pytest tests/test_serial_source.py tests/test_tx_service.py tests/test_serial_radio_handshake.py` (69 passed)
- [x] ruff clean on touched files
- [ ] Optional on RAK V2: reply to a serial-heard node and confirm stick TX log + recipient gets it