### PR TITLE
Multi-serial Meshtastic USB sticks (capture.serial)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,6 +28,13 @@ capture:
   sources: []
   serial_port: null
   serial_baud: 115200
+  # Opt-in multi-stick list (label becomes capture_source "serial_<label>"):
+  # serial:
+  #   - serial_port: "/dev/ttyUSB0"
+  #     label: "433"
+  #   - serial_port: "/dev/ttyUSB1"
+  #     label: "868"
+  serial: []
   concentrator_spi_device: "/dev/spidev0.0"
   meshcore_usb:
     serial_port: null

--- a/frontend/css/configuration.css
+++ b/frontend/css/configuration.css
@@ -97,6 +97,18 @@
     letter-spacing: 0;
 }
 
+.cfg-field__resolved {
+    display: block;
+    font-size: 12px;
+    font-family: 'JetBrains Mono', Menlo, monospace;
+    color: var(--accent-cyan, #22d3ee);
+    margin-top: 4px;
+}
+
+.cfg-field__resolved[hidden] {
+    display: none;
+}
+
 .cfg-field__hint--block {
     display: block;
     margin: 0 0 10px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -168,6 +168,7 @@
                             <li class="sidebar__subitem"><a href="#/configuration/radio" class="sidebar__link" data-route="configuration/radio"><span class="sidebar__label">Radio</span></a></li>
                             <li class="sidebar__subitem"><a href="#/configuration/channels" class="sidebar__link" data-route="configuration/channels"><span class="sidebar__label">Channels</span></a></li>
                             <li class="sidebar__subitem"><a href="#/configuration/meshcore" class="sidebar__link" data-route="configuration/meshcore"><span class="sidebar__label">MeshCore</span></a></li>
+                            <li class="sidebar__subitem"><a href="#/configuration/serial" class="sidebar__link" data-route="configuration/serial"><span class="sidebar__label">Serial</span></a></li>
                             <li class="sidebar__subitem"><a href="#/configuration/transmit" class="sidebar__link" data-route="configuration/transmit"><span class="sidebar__label">Transmit</span></a></li>
                             <li class="sidebar__subitem"><a href="#/configuration/mqtt" class="sidebar__link" data-route="configuration/mqtt"><span class="sidebar__label">MQTT</span></a></li>
                             <li class="sidebar__subitem"><a href="#/configuration/gps" class="sidebar__link" data-route="configuration/gps"><span class="sidebar__label">GPS</span></a></li>
@@ -280,6 +281,7 @@
                         <span class="topbar-meshcore__channel">--</span>
                     </span>
                 </div>
+                <div class="topbar__group topbar__group--serial" id="topbar-serial-group" hidden></div>
                 <div class="topbar__spacer" aria-hidden="true"></div>
                 <div class="topbar-actions" role="toolbar" aria-label="Quick actions"></div>
             </header>
@@ -486,6 +488,7 @@
             <section class="section" data-section="configuration/radio" style="display:none"><div id="cfg-radio-panel" class="section__placeholder"><h2>Configuration · Radio</h2><p>Skeleton; controls migrate from the Radio tab.</p></div></section>
             <section class="section" data-section="configuration/channels" style="display:none"><div id="cfg-channels-panel" class="section__placeholder"><h2>Configuration · Channels</h2><p>Skeleton; PSK list + add/remove.</p></div></section>
             <section class="section" data-section="configuration/meshcore" style="display:none"><div id="cfg-meshcore-panel" class="section__placeholder"><h2>Configuration · MeshCore</h2><p>Skeleton; companion channel keys + Send Advert.</p></div></section>
+            <section class="section" data-section="configuration/serial" style="display:none"><div id="cfg-serial-panel" class="section__placeholder"><h2>Configuration · Serial</h2><p>Loading…</p></div></section>
             <section class="section" data-section="configuration/transmit" style="display:none"><div id="cfg-transmit-panel" class="section__placeholder"><h2>Configuration · Transmit</h2><p>Skeleton; TX power + duty cycle + relay.</p></div></section>
             <section class="section" data-section="configuration/mqtt" style="display:none"><div id="cfg-mqtt-panel" class="section__placeholder"><h2>Configuration · MQTT</h2><p>Loading…</p></div></section>
             <section class="section" data-section="configuration/gps" style="display:none"><div id="cfg-gps-panel" class="section__placeholder"><h2>Configuration · GPS</h2><p>Loading…</p></div></section>
@@ -758,6 +761,7 @@
     <script src="js/configuration/quick_deploy_card.js"></script>
     <script src="js/configuration/channels_card.js"></script>
     <script src="js/configuration/meshcore_card.js"></script>
+    <script src="js/configuration/serial_card.js"></script>
     <script src="js/configuration/transmit_card.js"></script>
     <script src="js/configuration/mqtt_card.js"></script>
     <script src="js/configuration/gps_skyplot.js"></script>
@@ -789,6 +793,7 @@
     <script src="js/tab_title_telemetry.js"></script>
     <script src="topbar/topbar_meshtastic_chip.js"></script>
     <script src="topbar/topbar_meshcore_chip.js"></script>
+    <script src="topbar/topbar_serial_chip.js"></script>
     <script src="topbar/topbar_actions.js"></script>
     <script src="topbar/topbar_controller.js"></script>
     <script src="js/build_stamp.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -47,6 +47,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             'configuration/mqtt',
             'configuration/gps', 'configuration/advanced',
             'configuration/meshcore',
+            'configuration/serial',
             'settings/updates', 'settings/auth', 'settings/dangerous',
         ],
     });
@@ -516,6 +517,7 @@ function _bootCommandPaletteAndKeymap(router) {
         ['configuration/radio', 'Go to Configuration · Radio', 'Configuration'],
         ['configuration/channels', 'Go to Configuration · Channels', 'Configuration'],
         ['configuration/meshcore', 'Go to Configuration · MeshCore', 'Configuration'],
+        ['configuration/serial', 'Go to Configuration · Serial', 'Configuration'],
         ['settings/auth', 'Go to Settings · Auth', 'Settings'],
         ['settings/updates', 'Go to Settings · Updates', 'Settings'],
         ['settings/dangerous', 'Go to Settings · System', 'Settings'],

--- a/frontend/js/configuration/configuration_panel.js
+++ b/frontend/js/configuration/configuration_panel.js
@@ -128,6 +128,14 @@ class ConfigurationPanel {
                 card.mount(host);
                 this._cards.set('meshcore', card);
             }
+        } else if (section === 'serial' && window.SerialConfigCard) {
+            const host = document.getElementById('cfg-serial-panel');
+            if (host) {
+                host.innerHTML = '';
+                const card = new window.SerialConfigCard(api);
+                card.mount(host);
+                this._cards.set('serial', card);
+            }
         } else if (section === 'transmit' && window.TransmitConfigCard) {
             const host = document.getElementById('cfg-transmit-panel');
             if (host) {

--- a/frontend/js/configuration/serial_card.js
+++ b/frontend/js/configuration/serial_card.js
@@ -1,0 +1,239 @@
+/**
+ * Configuration → Serial (Meshtastic USB) card.
+ *
+ * Edits capture.serial (multi-stick list). Empty serial_port means
+ * meshtastic-python auto-detect. Credit: javastraat/meshpoint
+ * ``9af5625`` + ``d6adb1e`` / ``a0b2679`` port picker.
+ */
+
+class SerialConfigCard {
+    constructor(api) {
+        this._api = api;
+        this._root = null;
+        this._portsByStable = new Map();
+    }
+
+    _MAX_DEVICES = 4;
+
+    mount(root) {
+        this._root = root;
+        this._root.innerHTML = `
+            <div class="cfg-section" data-serial-root>
+                <article class="cfg-card">
+                    <header class="cfg-card__head">
+                        <h3 class="cfg-card__title">USB capture sources</h3>
+                        <p class="cfg-card__hint">
+                            One entry per Meshtastic USB stick (Heltec, T-Beam, etc.).
+                            Use a label like 433 or 868 so packets tag as serial_433.
+                            Up to ${this._MAX_DEVICES}. Requires a service restart after changes.
+                        </p>
+                    </header>
+                    <label class="cfg-field cfg-field--toggle">
+                        <input type="checkbox" data-serial-enable>
+                        <span class="cfg-field__label">Include serial capture source</span>
+                    </label>
+                    <div class="cfg-companions" data-serial-devices></div>
+                    <datalist id="serial-ports-list"></datalist>
+                    <div class="cfg-companions__add-row">
+                        <button class="terminal-button" type="button" data-serial-add-device>
+                            + Add device
+                        </button>
+                        <button class="terminal-button" type="button" data-serial-rescan-usb
+                                title="Re-scan connected USB devices">
+                            Rescan USB
+                        </button>
+                    </div>
+                    <div class="cfg-card__actions">
+                        <button class="terminal-button terminal-button--primary"
+                                type="button" data-serial-save>
+                            Save USB sources
+                        </button>
+                    </div>
+                    <p class="cfg-status" data-serial-status aria-live="polite"></p>
+                </article>
+            </div>
+        `;
+        this._devicesEl = this._root.querySelector('[data-serial-devices]');
+
+        this._root.querySelector('[data-serial-add-device]')
+            .addEventListener('click', () => this._addDeviceRow());
+        this._root.querySelector('[data-serial-save]')
+            .addEventListener('click', () => this._saveDevices());
+        this._root.querySelector('[data-serial-rescan-usb]')
+            .addEventListener('click', (e) => this._rescanUsb(e.currentTarget));
+        this._refreshSerialPortsList();
+    }
+
+    render(config) {
+        const cap = config.capture || {};
+        const devices = Array.isArray(cap.serial) ? cap.serial : [];
+        const sources = cap.sources || [];
+
+        const enableEl = this._root.querySelector('[data-serial-enable]');
+        if (enableEl) enableEl.checked = sources.includes('serial');
+
+        this._devicesEl.innerHTML = '';
+        const list = devices.length > 0
+            ? devices
+            : [{
+                label: '',
+                serial_port: cap.serial_port || '',
+                serial_baud: cap.serial_baud || 115200,
+            }];
+        list.forEach((d) => this._addDeviceRow(d));
+        this._syncAddBtn();
+    }
+
+    async _rescanUsb(button) {
+        const original = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Scanning…';
+        try {
+            await this._refreshSerialPortsList();
+            this._devicesEl.querySelectorAll('[data-device-port]').forEach((input) => {
+                this._updateResolvedPort(input);
+            });
+        } finally {
+            button.disabled = false;
+            button.textContent = original;
+        }
+    }
+
+    async _refreshSerialPortsList() {
+        const list = this._root.querySelector('#serial-ports-list');
+        if (!list) return;
+        const result = await this._api.get('/api/config/serial-ports');
+        const ports = (result && result.ports) || [];
+        this._portsByStable = new Map(
+            ports.map((p) => [p.stable_path, p]),
+        );
+        list.innerHTML = ports.map((p) => {
+            const label = this._esc(p.description || p.device);
+            const value = this._esc(p.stable_path);
+            return `<option value="${value}">${label}</option>`;
+        }).join('');
+    }
+
+    _addDeviceRow(data = {}) {
+        const idx = this._devicesEl.children.length;
+        if (idx >= this._MAX_DEVICES) return;
+
+        const label = this._esc(data.label || '');
+        const port = this._esc(data.serial_port || '');
+        const baud = data.serial_baud != null ? data.serial_baud : 115200;
+
+        const div = document.createElement('div');
+        div.className = 'cfg-companion';
+        div.dataset.deviceIdx = idx;
+        div.innerHTML = `
+            <div class="cfg-companion__header">
+                <span class="cfg-companion__num">Device ${idx + 1}</span>
+                <label class="cfg-companion__label-wrap">
+                    <span class="cfg-field__label">Label</span>
+                    <input class="cfg-field__input cfg-companion__label-input"
+                           type="text" maxlength="16"
+                           placeholder="e.g. 433 or 868"
+                           value="${label}" data-device-label>
+                </label>
+                <button class="cfg-companion__remove terminal-button terminal-button--danger"
+                        type="button" title="Remove device">✕</button>
+            </div>
+            <label class="cfg-field">
+                <span class="cfg-field__label">Pinned serial port</span>
+                <input class="cfg-field__input" type="text" list="serial-ports-list"
+                       placeholder="/dev/serial/by-path/… (blank = auto-detect)"
+                       value="${port}" data-device-port>
+                <span class="cfg-field__resolved" data-device-resolved hidden></span>
+            </label>
+            <label class="cfg-field cfg-field--narrow">
+                <span class="cfg-field__label">Baud rate</span>
+                <input class="cfg-field__input" type="number"
+                       value="${baud}" data-device-baud>
+            </label>
+        `;
+
+        div.querySelector('.cfg-companion__remove').addEventListener('click', () => {
+            div.remove();
+            this._reindexDevices();
+            this._syncAddBtn();
+        });
+
+        const portInput = div.querySelector('[data-device-port]');
+        portInput.addEventListener('input', () => this._updateResolvedPort(portInput));
+        portInput.addEventListener('change', () => this._updateResolvedPort(portInput));
+        this._updateResolvedPort(portInput);
+
+        this._devicesEl.appendChild(div);
+        this._syncAddBtn();
+    }
+
+    _updateResolvedPort(input) {
+        const hint = input.parentElement.querySelector('[data-device-resolved]');
+        if (!hint) return;
+        const value = (input.value || '').trim();
+        const info = this._portsByStable.get(value);
+        if (info && info.device && info.device !== value) {
+            hint.hidden = false;
+            hint.textContent = `→ ${info.device}`;
+        } else {
+            hint.hidden = true;
+            hint.textContent = '';
+        }
+    }
+
+    _reindexDevices() {
+        this._devicesEl.querySelectorAll('.cfg-companion').forEach((el, i) => {
+            el.dataset.deviceIdx = i;
+            const num = el.querySelector('.cfg-companion__num');
+            if (num) num.textContent = `Device ${i + 1}`;
+        });
+    }
+
+    _syncAddBtn() {
+        const btn = this._root.querySelector('[data-serial-add-device]');
+        if (!btn) return;
+        const count = this._devicesEl.children.length;
+        btn.disabled = count >= this._MAX_DEVICES;
+        btn.title = count >= this._MAX_DEVICES
+            ? `Maximum ${this._MAX_DEVICES} devices`
+            : '';
+    }
+
+    async _saveDevices() {
+        const status = this._root.querySelector('[data-serial-status]');
+        status.dataset.kind = 'pending';
+        status.textContent = 'Saving…';
+
+        const devices = [];
+        this._devicesEl.querySelectorAll('.cfg-companion').forEach((div) => {
+            devices.push({
+                label: (div.querySelector('[data-device-label]')?.value || '').trim(),
+                serial_port: (div.querySelector('[data-device-port]')?.value || '').trim() || null,
+                serial_baud: Number(div.querySelector('[data-device-baud]')?.value) || 115200,
+            });
+        });
+
+        const result = await this._api.put('/api/config/capture/serial-devices', {
+            enable_source: this._root.querySelector('[data-serial-enable]').checked,
+            devices,
+        });
+
+        if (result) {
+            status.dataset.kind = 'success';
+            status.textContent = 'Saved.';
+            this._api.signalRestart('Serial USB devices updated.');
+            await this._api.refresh();
+        } else {
+            status.dataset.kind = 'error';
+            status.textContent = 'Save failed.';
+        }
+    }
+
+    _esc(str) {
+        const el = document.createElement('span');
+        el.textContent = str || '';
+        return el.innerHTML;
+    }
+}
+
+window.SerialConfigCard = SerialConfigCard;

--- a/frontend/topbar/topbar.css
+++ b/frontend/topbar/topbar.css
@@ -360,4 +360,112 @@
     .topbar-meshtastic__preset { display: none; }
     .topbar-meshcore__name { max-width: 5rem; }
     .topbar-meshtastic__call { font-size: 0.78rem; }
+    .topbar-serial__preset { display: none; }
+}
+
+/* --- Serial Meshtastic USB device chip(s) --- */
+
+.topbar__group--serial {
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+
+.topbar-serial {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(6, 182, 212, 0.3);
+    background: rgba(6, 182, 212, 0.05);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--text-secondary);
+}
+
+.topbar-serial--offline,
+.topbar-serial--reconnecting {
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.topbar-serial__brand {
+    font-size: 0.55rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent-cyan);
+    opacity: 0.85;
+}
+
+.topbar-serial__lamp {
+    display: inline-flex;
+    align-items: center;
+}
+
+.topbar-serial__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+}
+
+.topbar-serial__lamp--online .topbar-serial__dot {
+    background: var(--accent-green, #00e5a0);
+    box-shadow: 0 0 6px rgba(0, 229, 160, 0.65);
+}
+
+.topbar-serial__lamp--offline .topbar-serial__dot,
+.topbar-serial__lamp--reconnecting .topbar-serial__dot {
+    background: var(--accent-red, #ef4444);
+    box-shadow: 0 0 6px rgba(239, 68, 68, 0.5);
+}
+
+.topbar-serial__lamp--reconnecting .topbar-serial__dot {
+    animation: topbar-meshtastic-blink 0.9s steps(2, end) infinite;
+}
+
+.topbar-serial__call {
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    color: var(--text-primary);
+    min-width: 3ch;
+}
+
+.topbar-serial__preset {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    border-left: 1px solid rgba(6, 182, 212, 0.22);
+    padding-left: 0.4rem;
+    margin-left: 0.05rem;
+}
+
+.topbar-serial__sep {
+    color: var(--text-muted);
+    opacity: 0.5;
+}
+
+.topbar-serial__sep--bar {
+    opacity: 0.35;
+    margin: 0 0.05rem;
+}
+
+.topbar-serial__region {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.topbar-serial__freq {
+    color: var(--accent-cyan);
+}
+
+.topbar-serial--offline .topbar-serial__region,
+.topbar-serial--offline .topbar-serial__freq,
+.topbar-serial--offline .topbar-serial__preset,
+.topbar-serial--reconnecting .topbar-serial__region,
+.topbar-serial--reconnecting .topbar-serial__freq,
+.topbar-serial--reconnecting .topbar-serial__preset {
+    opacity: 0.55;
 }

--- a/frontend/topbar/topbar_controller.js
+++ b/frontend/topbar/topbar_controller.js
@@ -20,6 +20,9 @@ class TopbarController {
             rootEl.querySelector('#topbar-meshcore-group'),
             rootEl.querySelector('.topbar-meshcore'),
         );
+        this._serial = new TopbarSerialChip(
+            rootEl.querySelector('#topbar-serial-group'),
+        );
         this._actions = new TopbarActions(
             rootEl.querySelector('.topbar-actions'),
         );
@@ -41,22 +44,27 @@ class TopbarController {
         if (!this._ws) {
             this._meshtastic.setConnectionState('offline');
             this._meshcore.setDashboardReachable(false);
+            this._serial.setDashboardReachable(false);
             return;
         }
         this._ws.on('connected', () => {
             this._meshtastic.setConnectionState('online');
             this._meshcore.setDashboardReachable(true);
+            this._serial.setDashboardReachable(true);
             this._refreshConfig();
         });
         this._ws.on('disconnected', () => {
             this._meshtastic.setConnectionState('reconnecting');
             this._meshcore.setDashboardReachable(false);
+            this._serial.setDashboardReachable(false);
         });
         if (this._ws.socket && this._ws.socket.readyState === 1) {
             this._meshtastic.setConnectionState('online');
             this._meshcore.setDashboardReachable(true);
+            this._serial.setDashboardReachable(true);
         } else {
             this._meshcore.setDashboardReachable(false);
+            this._serial.setDashboardReachable(false);
         }
     }
 
@@ -65,21 +73,25 @@ class TopbarController {
             const res = await fetch('/api/config', { credentials: 'same-origin' });
             if (!res.ok) {
                 this._meshcore.setDashboardReachable(false);
+                this._serial.setDashboardReachable(false);
                 return;
             }
             const cfg = await res.json();
             this._meshcore.setDashboardReachable(true);
+            this._serial.setDashboardReachable(true);
             const tx = cfg.transmit || {};
             this._meshtastic.setMeshtastic({
                 shortName: tx.short_name,
                 radio: cfg.radio || null,
             });
             this._meshcore.setMeshcore(cfg.meshcore || null);
+            this._serial.setSerial(cfg.serial || []);
             document.dispatchEvent(
                 new CustomEvent('meshpoint:configUpdated', { detail: cfg }),
             );
         } catch (_e) {
             this._meshcore.setDashboardReachable(false);
+            this._serial.setDashboardReachable(false);
         }
     }
 

--- a/frontend/topbar/topbar_serial_chip.js
+++ b/frontend/topbar/topbar_serial_chip.js
@@ -1,0 +1,129 @@
+/**
+ * Topbar — Meshtastic USB serial device chip(s).
+ *
+ * One cyan badge per live serial capture source. Credit:
+ * javastraat/meshpoint ``77cdaa2`` / ``7e0b863`` / ``0039adb``.
+ */
+class TopbarSerialChip {
+    constructor(groupEl) {
+        this._group = groupEl;
+        this._lastDevices = [];
+        this._dashboardReachable = false;
+    }
+
+    setSerial(devices) {
+        this._lastDevices = Array.isArray(devices) ? devices : [];
+        this._paint();
+    }
+
+    setDashboardReachable(reachable) {
+        this._dashboardReachable = Boolean(reachable);
+        this._paint();
+    }
+
+    _paint() {
+        const list = this._lastDevices;
+        this._group.hidden = list.length === 0;
+        this._group.textContent = '';
+        list.forEach((dev) => this._group.appendChild(this._buildBadge(dev)));
+    }
+
+    _buildBadge(dev) {
+        const reachable = this._dashboardReachable;
+        const connected = reachable && Boolean(dev.connected);
+        const ownId = this._shortNodeId(dev.own_node_id_hex);
+        const callText = !reachable ? '----' : (ownId || '----');
+
+        const root = document.createElement('span');
+        root.className = 'topbar-serial';
+        if (!reachable) {
+            root.classList.add('topbar-serial--reconnecting');
+        } else if (!connected) {
+            root.classList.add('topbar-serial--offline');
+        }
+        root.setAttribute(
+            'aria-label',
+            `Meshtastic USB ${ownId || 'device'} `
+                + `${!reachable ? 'reconnecting' : (connected ? 'connected' : 'offline')}`,
+        );
+
+        const brand = document.createElement('span');
+        brand.className = 'topbar-serial__brand';
+        brand.textContent = 'Meshtastic';
+        root.appendChild(brand);
+
+        const lampState = !reachable ? 'reconnecting' : (connected ? 'online' : 'offline');
+        const lamp = document.createElement('span');
+        lamp.className = `topbar-serial__lamp topbar-serial__lamp--${lampState}`;
+        lamp.setAttribute('role', 'status');
+        const dot = document.createElement('span');
+        dot.className = 'topbar-serial__dot';
+        dot.setAttribute('aria-hidden', 'true');
+        lamp.appendChild(dot);
+        root.appendChild(lamp);
+
+        const call = document.createElement('span');
+        call.className = 'topbar-serial__call';
+        call.textContent = ownId ? `!${ownId}` : callText;
+        root.appendChild(call);
+
+        root.appendChild(this._sep());
+        const region = document.createElement('span');
+        region.className = 'topbar-serial__region';
+        region.textContent = (reachable && dev.region) ? String(dev.region) : '--';
+        root.appendChild(region);
+
+        root.appendChild(this._sep());
+        const freq = document.createElement('span');
+        freq.className = 'topbar-serial__freq';
+        const mhz = Number(dev.frequency_mhz);
+        freq.textContent = (reachable && mhz > 0)
+            ? `${mhz.toFixed(3)} MHz`
+            : '--';
+        root.appendChild(freq);
+
+        const sepBar = this._sep();
+        sepBar.classList.add('topbar-serial__sep--bar');
+        root.appendChild(sepBar);
+
+        const preset = document.createElement('span');
+        preset.className = 'topbar-serial__preset';
+        preset.textContent = this._formatPreset(reachable ? dev.modem_preset : null);
+        root.appendChild(preset);
+
+        return root;
+    }
+
+    _sep() {
+        const el = document.createElement('span');
+        el.className = 'topbar-serial__sep';
+        el.setAttribute('aria-hidden', 'true');
+        el.textContent = '·';
+        return el;
+    }
+
+    _shortNodeId(hex) {
+        if (!hex) return null;
+        const clean = String(hex).replace(/^!/, '').toLowerCase();
+        if (!/^[0-9a-f]{8}$/.test(clean)) return null;
+        return clean.slice(-4);
+    }
+
+    _formatPreset(name) {
+        if (!name || name === 'CUSTOM') return 'Custom';
+        const labels = {
+            LONG_FAST: 'LongFast',
+            LONG_SLOW: 'LongSlow',
+            LONG_MODERATE: 'LongMod',
+            LONG_TURBO: 'LongTurbo',
+            MEDIUM_FAST: 'MediumFast',
+            MEDIUM_SLOW: 'MediumSlow',
+            SHORT_FAST: 'ShortFast',
+            SHORT_SLOW: 'ShortSlow',
+            SHORT_TURBO: 'ShortTurbo',
+        };
+        return labels[String(name)] || String(name);
+    }
+}
+
+window.TopbarSerialChip = TopbarSerialChip;

--- a/src/api/routes/config_enrichment.py
+++ b/src/api/routes/config_enrichment.py
@@ -37,7 +37,17 @@ def enrich_config_payload(cfg: AppConfig, base: dict) -> dict:
     }
     base["capture"] = {
         "sources": list(capture.sources or []),
+        "serial_port": capture.serial_port,
+        "serial_baud": capture.serial_baud,
         "concentrator_spi_device": capture.concentrator_spi_device,
+        "serial": [
+            {
+                "serial_port": d.serial_port,
+                "serial_baud": d.serial_baud,
+                "label": d.label,
+            }
+            for d in capture.serial
+        ],
         "meshcore_usb": {
             "serial_port": mc_usb.serial_port,
             "baud_rate": mc_usb.baud_rate,

--- a/src/api/routes/config_routes.py
+++ b/src/api/routes/config_routes.py
@@ -44,6 +44,7 @@ _crypto = None
 _tx_service = None
 _identity: DeviceIdentity | None = None
 _channel_hash_resolver = None
+_serial_sources: list = []
 
 
 def init_routes(
@@ -52,13 +53,42 @@ def init_routes(
     tx_service=None,
     identity: DeviceIdentity | None = None,
     channel_hash_resolver=None,
+    serial_sources: list | None = None,
 ) -> None:
     global _config, _crypto, _tx_service, _identity, _channel_hash_resolver
+    global _serial_sources
     _config = config
     _crypto = crypto
     _tx_service = tx_service
     _identity = identity
     _channel_hash_resolver = channel_hash_resolver
+    _serial_sources = serial_sources or []
+
+
+def _serial_status_entry(src) -> dict:
+    """Topbar / config status for one Meshtastic USB serial source."""
+    from src.radio.channel_frequency import resolve_frequency_mhz
+
+    info = src.get_radio_info() if hasattr(src, "get_radio_info") else {}
+    own_node_num = info.get("own_node_num")
+    return {
+        "name": src.name,
+        "connected": bool(getattr(src, "connected", False)),
+        "frequency_mhz": resolve_frequency_mhz(
+            region=info.get("region"),
+            channel_num=info.get("channel_num"),
+            bandwidth_khz=info.get("bandwidth_khz") or 250.0,
+            channel_name=info.get("channel_name"),
+            modem_preset=info.get("modem_preset"),
+            use_preset=info.get("use_preset", True),
+            frequency_offset=info.get("frequency_offset") or 0.0,
+            override_frequency=info.get("override_frequency") or 0.0,
+        ),
+        **info,
+        "own_node_id_hex": (
+            f"{own_node_num:08x}" if own_node_num is not None else None
+        ),
+    }
 
 
 def _refresh_channel_hash_map() -> None:
@@ -185,6 +215,7 @@ async def get_config():
         ),
         "channels": channels,
         "meshcore": mc_status,
+        "serial": [_serial_status_entry(src) for src in _serial_sources],
         "duty_cycle": duty_info,
         "presets": all_presets_list(),
         "regions": [

--- a/src/api/routes/identity_routes.py
+++ b/src/api/routes/identity_routes.py
@@ -45,6 +45,7 @@ _ADMIN_SECTIONS: tuple[str, ...] = (
     "configuration.radio",
     "configuration.channels",
     "configuration.meshcore",
+    "configuration.serial",
     "configuration.transmit",
     "configuration.mqtt",
     "configuration.gps",

--- a/src/api/routes/system_config_routes.py
+++ b/src/api/routes/system_config_routes.py
@@ -43,6 +43,17 @@ class MeshcoreUsbUpdate(BaseModel):
     enable_source: Optional[bool] = None
 
 
+class SerialDeviceEntry(BaseModel):
+    label: str = ""
+    serial_port: Optional[str] = None
+    serial_baud: int = Field(115200, ge=9600, le=921600)
+
+
+class SerialDevicesUpdate(BaseModel):
+    devices: list[SerialDeviceEntry] = Field(..., min_length=0, max_length=4)
+    enable_source: Optional[bool] = None
+
+
 class RelayUpdate(BaseModel):
     enabled: Optional[bool] = None
     serial_port: Optional[str] = None
@@ -209,6 +220,81 @@ async def update_relay(
     return {"saved": True, "restart_required": restart_needed, "updates": updates}
 
 
+@router.put("/capture/serial-devices")
+async def update_serial_devices(
+    req: SerialDevicesUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+    audit: AuditLogWriter = Depends(get_audit_writer),
+):
+    """Replace the Meshtastic USB serial device list (up to 4 entries)."""
+    from src.config import SerialDeviceConfig
+
+    if _config is None:
+        raise HTTPException(503, "Config not loaded")
+
+    new_devices = [
+        SerialDeviceConfig(
+            label=d.label.strip(),
+            serial_port=(d.serial_port or "").strip() or None,
+            serial_baud=d.serial_baud,
+        )
+        for d in req.devices
+    ]
+    _config.capture.serial = new_devices
+
+    devices_list = [_serial_device_dict(d) for d in new_devices]
+    yaml_updates: dict = {"serial": devices_list}
+    capture_updates: dict = {}
+
+    sources = list(_config.capture.sources or [])
+    if req.enable_source is not None:
+        has_serial = "serial" in sources
+        if req.enable_source and not has_serial:
+            sources.append("serial")
+            capture_updates["sources"] = sources
+            _config.capture.sources = sources
+        elif not req.enable_source and has_serial:
+            sources = [s for s in sources if s != "serial"]
+            capture_updates["sources"] = sources
+            _config.capture.sources = sources
+
+    with audit.timed_action(
+        user=_claims.subject,
+        action="config.serial_devices_update",
+        params={"devices": devices_list},
+    ):
+        try:
+            save_section_to_yaml("capture", {**yaml_updates, **capture_updates})
+        except PermissionError as exc:
+            raise HTTPException(403, str(exc)) from exc
+
+    return {"saved": True, "restart_required": True}
+
+
+@router.get("/serial-ports")
+async def list_serial_ports(
+    _claims: SessionClaims = Depends(require_admin),
+):
+    """Connected USB-serial devices for the Configuration port picker."""
+    from src.hal.usb_classifier import list_serial_ports_with_stable_paths
+
+    ports = list_serial_ports_with_stable_paths()
+    return {
+        "ports": [
+            {
+                "device": p.device,
+                "stable_path": p.stable_path,
+                "by_id": p.by_id,
+                "by_path": p.by_path,
+                "description": p.description,
+                "vid": f"{p.vid:04x}" if p.vid is not None else None,
+                "pid": f"{p.pid:04x}" if p.pid is not None else None,
+            }
+            for p in ports
+        ]
+    }
+
+
 @router.put("/radio/advanced")
 async def update_radio_advanced(
     req: RadioAdvancedUpdate,
@@ -251,4 +337,12 @@ def _meshcore_usb_dict(mc_usb) -> dict:
         "serial_port": mc_usb.serial_port,
         "baud_rate": mc_usb.baud_rate,
         "auto_detect": mc_usb.auto_detect,
+    }
+
+
+def _serial_device_dict(dev) -> dict:
+    return {
+        "serial_port": dev.serial_port,
+        "serial_baud": dev.serial_baud,
+        "label": dev.label,
     }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -361,17 +361,28 @@ def _build_pipeline(config: AppConfig) -> PipelineCoordinator:
 
 
 def _add_serial_source(coordinator: PipelineCoordinator, config: AppConfig):
+    """Add one SerialCaptureSource per configured Meshtastic USB device."""
     try:
         from src.capture.serial_source import SerialCaptureSource
-        coordinator.capture_coordinator.add_source(
-            SerialCaptureSource(
-                port=config.capture.serial_port,
-                baud=config.capture.serial_baud,
-            )
-        )
+        from src.config import SerialDeviceConfig
     except ImportError:
         logger.warning("Serial capture unavailable")
+        return
 
+    devices = config.capture.serial or [
+        SerialDeviceConfig(
+            serial_port=config.capture.serial_port,
+            serial_baud=config.capture.serial_baud,
+        )
+    ]
+    for dev in devices:
+        coordinator.capture_coordinator.add_source(
+            SerialCaptureSource(
+                port=dev.serial_port,
+                baud=dev.serial_baud,
+                label=dev.label,
+            )
+        )
 
 def _add_concentrator_source(
     coordinator: PipelineCoordinator, config: AppConfig
@@ -1346,6 +1357,7 @@ def _init_routes(
         tx_service=tx_service,
         identity=identity,
         channel_hash_resolver=channel_hash_resolver,
+        serial_sources=_find_serial_sources(coord),
     )
     mqtt_config_routes.init_routes(
         config=config,

--- a/src/capture/serial_source.py
+++ b/src/capture/serial_source.py
@@ -81,9 +81,11 @@ class SerialCaptureSource(CaptureSource):
         self,
         port: Optional[str] = None,
         baud: int = 115200,
+        label: str = "",
     ):
         self._port = port
         self._baud = baud
+        self._label = (label or "").strip()
         self._interface = None
         self._running = False
         self._self_origin = SerialSelfOriginFilter()
@@ -92,7 +94,7 @@ class SerialCaptureSource(CaptureSource):
 
     @property
     def name(self) -> str:
-        return "serial"
+        return f"serial_{self._label}" if self._label else "serial"
 
     @property
     def is_running(self) -> bool:
@@ -125,6 +127,7 @@ class SerialCaptureSource(CaptureSource):
             own_node = SerialSelfOriginFilter.read_own_node_num(self._interface)
             self._self_origin.set_own_node_num(own_node)
             self._radio_info = SerialRadioHandshake.read(self._interface)
+            self._radio_info["own_node_num"] = own_node
             try:
                 modem_preset = self._radio_info.get("modem_preset")
                 if modem_preset == "CUSTOM":
@@ -273,8 +276,12 @@ class SerialCaptureSource(CaptureSource):
                 continue
 
     def _on_receive(self, packet, interface) -> None:
-        """Callback invoked by meshtastic-python on packet reception."""
-        if not self._running:
+        """Callback invoked by meshtastic-python on packet reception.
+
+        meshtastic-python publishes every open interface on one process-wide
+        topic, so multi-stick setups must ignore foreign interfaces.
+        """
+        if not self._running or interface is not self._interface:
             return
 
         try:

--- a/src/config.py
+++ b/src/config.py
@@ -98,10 +98,42 @@ class MeshcoreUsbConfig:
 
 
 @dataclass
+class SerialDeviceConfig:
+    """One Meshtastic USB serial radio.
+
+    Optional list under ``capture.serial``. Single-stick setups can keep
+    using the legacy ``capture.serial_port`` / ``serial_baud`` scalars.
+    """
+
+    serial_port: Optional[str] = None
+    serial_baud: int = 115200
+    label: str = ""
+
+
+_SERIAL_DEVICE_FIELDS: frozenset[str] = frozenset(
+    {"serial_port", "serial_baud", "label"}
+)
+
+
+def _coerce_serial_devices(value) -> list[SerialDeviceConfig]:
+    """Parse opt-in multi-device ``capture.serial`` list (list of dicts only)."""
+
+    def _from_dict(d: dict) -> SerialDeviceConfig:
+        return SerialDeviceConfig(
+            **{k: v for k, v in d.items() if k in _SERIAL_DEVICE_FIELDS}
+        )
+
+    if isinstance(value, list):
+        return [_from_dict(d) for d in value if isinstance(d, dict)]
+    return []
+
+
+@dataclass
 class CaptureConfig:
     sources: list[str] = field(default_factory=lambda: ["mock"])
     serial_port: Optional[str] = None
     serial_baud: int = 115200
+    serial: list[SerialDeviceConfig] = field(default_factory=list)
     concentrator_spi_device: str = "/dev/spidev0.0"
     meshcore_usb: MeshcoreUsbConfig = field(default_factory=MeshcoreUsbConfig)
 
@@ -395,6 +427,13 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
         logger.warning("Ignoring %s: top-level YAML is not a mapping.", path)
         return
 
+    # Opt-in multi-device list; pop before merge so nested dicts become
+    # SerialDeviceConfig instances (legacy serial_port scalars untouched).
+    cap_raw = raw.get("capture")
+    serial_devices: list[SerialDeviceConfig] | None = None
+    if isinstance(cap_raw, dict) and "serial" in cap_raw:
+        serial_devices = _coerce_serial_devices(cap_raw.pop("serial"))
+
     section_map = {
         "radio": cfg.radio,
         "meshtastic": cfg.meshtastic,
@@ -423,6 +462,9 @@ def _apply_yaml(cfg: AppConfig, path: Path) -> None:
             unknown_keys.extend(
                 _collect_unknown_keys(section_instance, section_value, f"{section_name}.")
             )
+
+    if serial_devices is not None:
+        cfg.capture.serial = serial_devices
 
     if unknown_keys:
         logger.warning(

--- a/src/hal/usb_classifier.py
+++ b/src/hal/usb_classifier.py
@@ -24,11 +24,16 @@ MeshCore handshake probe is the right disambiguator there.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+_BY_ID_DIR = Path("/dev/serial/by-id")
+_BY_PATH_DIR = Path("/dev/serial/by-path")
 
 
 class PortClass(str, Enum):
@@ -105,6 +110,66 @@ class UsbPortClassifier:
             for info in self.list_ports()
             if info.port_class is PortClass.GPS_KNOWN
         ]
+
+
+def _resolve_symlinks(directory: Path) -> dict[str, str]:
+    """Map real device path -> first symlink name pointing at it."""
+    result: dict[str, str] = {}
+    if not directory.is_dir():
+        return result
+    for entry in sorted(directory.iterdir()):
+        try:
+            target = os.path.realpath(entry)
+        except OSError:
+            continue
+        result.setdefault(target, str(entry))
+    return result
+
+
+@dataclass(frozen=True)
+class StablePortInfo:
+    """One USB-serial device with a recommended stable pin path."""
+
+    device: str
+    stable_path: str
+    by_id: Optional[str]
+    by_path: Optional[str]
+    description: str
+    vid: Optional[int]
+    pid: Optional[int]
+
+
+def list_serial_ports_with_stable_paths() -> list[StablePortInfo]:
+    """Enumerate ports for the dashboard picker (by-path > by-id > device)."""
+    classifier = UsbPortClassifier()
+    by_id = _resolve_symlinks(_BY_ID_DIR)
+    by_path = _resolve_symlinks(_BY_PATH_DIR)
+
+    ports: list[StablePortInfo] = []
+    for info in classifier.list_ports():
+        try:
+            real = os.path.realpath(info.device)
+        except OSError:
+            real = info.device
+        id_path = by_id.get(real)
+        path_path = by_path.get(real)
+        stable = path_path or id_path or info.device
+        description = (
+            " ".join(p for p in (info.manufacturer, info.product) if p)
+            or info.device
+        )
+        ports.append(
+            StablePortInfo(
+                device=info.device,
+                stable_path=stable,
+                by_id=id_path,
+                by_path=path_path,
+                description=description,
+                vid=info.vid,
+                pid=info.pid,
+            )
+        )
+    return ports
 
 
 def should_skip_for_meshcore_probe(port: str) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -16,15 +16,26 @@ logger = logging.getLogger("concentrator")
 def _add_serial_source(coordinator: PipelineCoordinator, config) -> None:
     try:
         from src.capture.serial_source import SerialCaptureSource
-        coordinator.capture_coordinator.add_source(
-            SerialCaptureSource(
-                port=config.capture.serial_port,
-                baud=config.capture.serial_baud,
-            )
-        )
+        from src.config import SerialDeviceConfig
     except ImportError:
         logger.warning(
             "Serial capture unavailable -- meshtastic package not installed"
+        )
+        return
+
+    devices = config.capture.serial or [
+        SerialDeviceConfig(
+            serial_port=config.capture.serial_port,
+            serial_baud=config.capture.serial_baud,
+        )
+    ]
+    for dev in devices:
+        coordinator.capture_coordinator.add_source(
+            SerialCaptureSource(
+                port=dev.serial_port,
+                baud=dev.serial_baud,
+                label=dev.label,
+            )
         )
 
 

--- a/tests/test_config_loader_serial.py
+++ b/tests/test_config_loader_serial.py
@@ -1,0 +1,88 @@
+"""Tests for multi-stick ``capture.serial`` config coercion.
+
+Credit: javastraat/meshpoint ``deda84b``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.config import (
+    AppConfig,
+    CaptureConfig,
+    SerialDeviceConfig,
+    _apply_yaml,
+    _coerce_serial_devices,
+)
+
+
+class SerialDeviceConfigTest(unittest.TestCase):
+    def _write(self, text: str) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        )
+        tmp.write(text)
+        tmp.close()
+        path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
+    def test_default_is_empty_list(self):
+        cap = CaptureConfig()
+        self.assertEqual(cap.serial, [])
+
+    def test_serial_device_config_defaults(self):
+        dev = SerialDeviceConfig()
+        self.assertIsNone(dev.serial_port)
+        self.assertEqual(dev.serial_baud, 115200)
+        self.assertEqual(dev.label, "")
+
+    def test_coerce_parses_list_of_dicts(self):
+        devices = _coerce_serial_devices([
+            {"serial_port": "/dev/ttyUSB0", "label": "433"},
+            {"serial_port": "/dev/ttyUSB1", "label": "868", "serial_baud": 57600},
+        ])
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(devices[0].serial_port, "/dev/ttyUSB0")
+        self.assertEqual(devices[0].label, "433")
+        self.assertEqual(devices[0].serial_baud, 115200)
+        self.assertEqual(devices[1].serial_baud, 57600)
+
+    def test_coerce_ignores_non_list_value(self):
+        self.assertEqual(
+            _coerce_serial_devices({"serial_port": "/dev/ttyUSB0"}), [],
+        )
+        self.assertEqual(_coerce_serial_devices(None), [])
+
+    def test_apply_yaml_populates_serial_list(self):
+        cfg = AppConfig()
+        path = self._write(
+            "capture:\n"
+            "  serial:\n"
+            "    - serial_port: /dev/ttyUSB0\n"
+            "      label: \"433\"\n"
+            "    - serial_port: /dev/ttyUSB1\n"
+            "      label: \"868\"\n"
+        )
+        with self.assertNoLogs("src.config", level="WARNING"):
+            _apply_yaml(cfg, path)
+        self.assertEqual(len(cfg.capture.serial), 2)
+        self.assertEqual(cfg.capture.serial[0].label, "433")
+        self.assertEqual(cfg.capture.serial[1].serial_port, "/dev/ttyUSB1")
+
+    def test_legacy_scalar_config_unaffected(self):
+        cfg = AppConfig()
+        path = self._write(
+            "capture:\n"
+            "  serial_port: /dev/ttyUSB0\n"
+            "  serial_baud: 115200\n"
+        )
+        _apply_yaml(cfg, path)
+        self.assertEqual(cfg.capture.serial, [])
+        self.assertEqual(cfg.capture.serial_port, "/dev/ttyUSB0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multi_serial_pipeline.py
+++ b/tests/test_multi_serial_pipeline.py
@@ -1,0 +1,58 @@
+"""Multi-serial source wiring tests.
+
+Credit: javastraat/meshpoint ``deda84b``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.api.server import _add_serial_source
+from src.config import AppConfig, SerialDeviceConfig
+
+
+class AddSerialSourceTest(unittest.TestCase):
+    def test_legacy_scalars_add_one_unlabelled_source(self):
+        config = AppConfig()
+        config.capture.serial_port = "/dev/ttyUSB0"
+        config.capture.serial = []
+        coord = MagicMock()
+        coord.capture_coordinator = MagicMock()
+
+        with patch("src.capture.serial_source.SerialCaptureSource") as cls:
+            instance = MagicMock()
+            instance.name = "serial"
+            cls.return_value = instance
+            _add_serial_source(coord, config)
+
+        cls.assert_called_once_with(
+            port="/dev/ttyUSB0", baud=115200, label=""
+        )
+        coord.capture_coordinator.add_source.assert_called_once_with(instance)
+
+    def test_serial_list_adds_labelled_sources(self):
+        config = AppConfig()
+        config.capture.serial = [
+            SerialDeviceConfig(serial_port="/dev/ttyUSB0", label="433"),
+            SerialDeviceConfig(serial_port="/dev/ttyUSB1", label="868"),
+        ]
+        coord = MagicMock()
+        coord.capture_coordinator = MagicMock()
+
+        with patch("src.capture.serial_source.SerialCaptureSource") as cls:
+            a = MagicMock()
+            a.name = "serial_433"
+            b = MagicMock()
+            b.name = "serial_868"
+            cls.side_effect = [a, b]
+            _add_serial_source(coord, config)
+
+        self.assertEqual(cls.call_count, 2)
+        cls.assert_any_call(port="/dev/ttyUSB0", baud=115200, label="433")
+        cls.assert_any_call(port="/dev/ttyUSB1", baud=115200, label="868")
+        self.assertEqual(coord.capture_coordinator.add_source.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serial_devices_route.py
+++ b/tests/test_serial_devices_route.py
@@ -1,0 +1,91 @@
+"""PUT /api/config/capture/serial-devices route tests.
+
+Credit: javastraat/meshpoint ``9af5625``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.auth.jwt_session import SessionClaims
+from src.api.routes import system_config_routes
+from src.config import AppConfig
+
+
+class SerialDevicesRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.config = AppConfig()
+        self.config.capture.sources = ["concentrator"]
+        system_config_routes.init_routes(self.config)
+
+        app = FastAPI()
+        app.include_router(system_config_routes.router)
+
+        async def _admin():
+            return SessionClaims(
+                subject="admin", role="admin", session_version=1
+            )
+
+        from src.api.auth.dependencies import require_admin
+        from src.api.audit.dependencies import get_audit_writer
+
+        app.dependency_overrides[require_admin] = _admin
+        app.dependency_overrides[get_audit_writer] = lambda: MagicMock(
+            timed_action=MagicMock(
+                return_value=MagicMock(
+                    __enter__=MagicMock(return_value=None),
+                    __exit__=MagicMock(return_value=False),
+                )
+            )
+        )
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        system_config_routes.reset_routes()
+
+    @patch("src.api.routes.system_config_routes.save_section_to_yaml")
+    def test_put_replaces_device_list(self, save_mock):
+        resp = self.client.put(
+            "/api/config/capture/serial-devices",
+            json={
+                "enable_source": True,
+                "devices": [
+                    {"label": "433", "serial_port": "/dev/ttyUSB0", "serial_baud": 115200},
+                    {"label": "868", "serial_port": "/dev/ttyUSB1"},
+                ],
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["restart_required"])
+        self.assertEqual(len(self.config.capture.serial), 2)
+        self.assertEqual(self.config.capture.serial[0].label, "433")
+        self.assertIn("serial", self.config.capture.sources)
+        save_mock.assert_called_once()
+
+    @patch("src.api.routes.system_config_routes.save_section_to_yaml")
+    def test_blank_port_becomes_none(self, save_mock):
+        resp = self.client.put(
+            "/api/config/capture/serial-devices",
+            json={"devices": [{"label": "auto", "serial_port": "  "}]},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(self.config.capture.serial[0].serial_port)
+
+    @patch("src.api.routes.system_config_routes.save_section_to_yaml")
+    def test_disable_removes_serial_source(self, save_mock):
+        self.config.capture.sources = ["concentrator", "serial"]
+        resp = self.client.put(
+            "/api/config/capture/serial-devices",
+            json={"enable_source": False, "devices": []},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("serial", self.config.capture.sources)
+        self.assertEqual(self.config.capture.serial, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -249,6 +249,39 @@ class ResolveChannelIndexTest(unittest.TestCase):
         self.assertIsNone(source.resolve_channel_index("LongFast"))
 
 
+class SerialSourceNameTest(unittest.TestCase):
+    def test_unlabelled_name_is_serial(self):
+        self.assertEqual(SerialCaptureSource(port="/dev/ttyUSB0").name, "serial")
+
+    def test_labelled_name_is_serial_label(self):
+        self.assertEqual(
+            SerialCaptureSource(port="/dev/ttyUSB0", label="433").name,
+            "serial_433",
+        )
+
+
+class PubsubInterfaceGuardTest(unittest.TestCase):
+    def test_ignores_packets_from_foreign_interface(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._running = True
+        source._interface = object()
+        source._queue = __import__("asyncio").Queue()
+        source._on_receive({"from": 1, "raw": b"\x00" * 16}, interface=object())
+        self.assertTrue(source._queue.empty())
+
+    def test_accepts_packets_from_own_interface(self):
+        source = SerialCaptureSource(port="/dev/ttyUSB0")
+        source._running = True
+        iface = object()
+        source._interface = iface
+        source._queue = __import__("asyncio").Queue()
+        source._on_receive(
+            {"from": 1, "raw": b"\x00" * 16, "rxRssi": -80, "rxSnr": 5},
+            interface=iface,
+        )
+        self.assertFalse(source._queue.empty())
+
+
 class ReconstructRawTest(unittest.TestCase):
     """MeshPacket raw is a protobuf object; encrypted is base64."""
 

--- a/tests/test_serial_status_entry.py
+++ b/tests/test_serial_status_entry.py
@@ -1,0 +1,51 @@
+"""Serial status entry + source discovery helpers.
+
+Credit: javastraat/meshpoint ``77cdaa2``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from src.api.routes.config_routes import _serial_status_entry
+from src.api.server import _find_serial_sources
+from src.capture.serial_source import SerialCaptureSource
+
+
+class SerialStatusEntryTest(unittest.TestCase):
+    def test_includes_name_connected_freq_and_own_id(self):
+        src = MagicMock()
+        src.name = "serial_433"
+        src.connected = True
+        src.get_radio_info.return_value = {
+            "region": "EU_868",
+            "channel_num": 0,
+            "bandwidth_khz": 250.0,
+            "channel_name": "",
+            "modem_preset": "LONG_FAST",
+            "use_preset": True,
+            "frequency_offset": 0.0,
+            "override_frequency": 0.0,
+            "own_node_num": 0xAABBCCDD,
+        }
+        entry = _serial_status_entry(src)
+        self.assertEqual(entry["name"], "serial_433")
+        self.assertTrue(entry["connected"])
+        self.assertEqual(entry["frequency_mhz"], 869.525)
+        self.assertEqual(entry["own_node_id_hex"], "aabbccdd")
+
+
+class FindSerialSourcesTest(unittest.TestCase):
+    def test_returns_only_serial_capture_sources(self):
+        serial = SerialCaptureSource(port="/dev/ttyUSB0", label="433")
+        other = MagicMock()
+        other.name = "concentrator"
+        coord = MagicMock()
+        coord.capture_coordinator._sources = [other, serial]
+        found = _find_serial_sources(coord)
+        self.assertEqual(found, [serial])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_usb_stable_ports.py
+++ b/tests/test_usb_stable_ports.py
@@ -1,0 +1,55 @@
+"""Stable USB serial path enumeration helpers.
+
+Credit: javastraat/meshpoint ``d6adb1e``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from src.hal.usb_classifier import (
+    PortClass,
+    PortInfo,
+    StablePortInfo,
+    list_serial_ports_with_stable_paths,
+)
+
+
+class ListSerialPortsStablePathsTest(unittest.TestCase):
+    @patch("src.hal.usb_classifier._resolve_symlinks")
+    @patch("src.hal.usb_classifier.UsbPortClassifier.list_ports")
+    def test_prefers_by_path_over_by_id(self, list_ports, resolve):
+        list_ports.return_value = [
+            PortInfo(
+                device="/dev/ttyUSB0",
+                vid=0x10C4,
+                pid=0xEA60,
+                manufacturer="Silicon Labs",
+                product="CP210x",
+                port_class=PortClass.UNKNOWN,
+            )
+        ]
+
+        def _resolve(directory):
+            name = str(directory)
+            if name.endswith("by-path"):
+                return {"/dev/ttyUSB0": "/dev/serial/by-path/platform-usb-0"}
+            if name.endswith("by-id"):
+                return {"/dev/ttyUSB0": "/dev/serial/by-id/usb-Silicon_Labs"}
+            return {}
+
+        resolve.side_effect = _resolve
+
+        with patch("src.hal.usb_classifier.os.path.realpath", side_effect=lambda p: p):
+            ports = list_serial_ports_with_stable_paths()
+
+        self.assertEqual(len(ports), 1)
+        self.assertIsInstance(ports[0], StablePortInfo)
+        self.assertEqual(
+            ports[0].stable_path, "/dev/serial/by-path/platform-usb-0"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `capture.serial` device list (label + port + baud) with legacy scalar fallback
- Name each `SerialCaptureSource` uniquely; Configuration → Serial UI + stable by-path port picker
- Topbar per-stick chips from handshake; `PUT /api/config/capture/serial-devices` + port list API

Rewritten from javastraat/meshpoint (not a blind cherry-pick). Co-authored by Albert Einstein.

## Test plan
- [x] `pytest` multi-serial + serial source + USB stable ports (79 related tests)
- [x] `ruff check` on touched Python
- [ ] Optional: two Heltec sticks on RAK V2, save ports in Configuration → Serial, confirm topbar chips + dual RX