### PR TITLE
Fix blank serial row crashing startup

### DIFF
--- a/frontend/js/configuration/serial_card.js
+++ b/frontend/js/configuration/serial_card.js
@@ -206,9 +206,13 @@ class SerialConfigCard {
 
         const devices = [];
         this._devicesEl.querySelectorAll('.cfg-companion').forEach((div) => {
+            const serialPort = (div.querySelector('[data-device-port]')?.value || '').trim();
+            if (!serialPort) {
+                return;
+            }
             devices.push({
                 label: (div.querySelector('[data-device-label]')?.value || '').trim(),
-                serial_port: (div.querySelector('[data-device-port]')?.value || '').trim() || null,
+                serial_port: serialPort,
                 serial_baud: Number(div.querySelector('[data-device-baud]')?.value) || 115200,
             });
         });

--- a/src/api/routes/system_config_routes.py
+++ b/src/api/routes/system_config_routes.py
@@ -232,18 +232,28 @@ async def update_serial_devices(
     if _config is None:
         raise HTTPException(503, "Config not loaded")
 
+    # Drop empty UI rows. A missing port would auto-open the first USB
+    # serial device and collide with a sibling stick (exclusive lock).
     new_devices = [
         SerialDeviceConfig(
             label=d.label.strip(),
-            serial_port=(d.serial_port or "").strip() or None,
+            serial_port=port,
             serial_baud=d.serial_baud,
         )
         for d in req.devices
+        for port in [(d.serial_port or "").strip() or None]
+        if port
     ]
     _config.capture.serial = new_devices
+    if new_devices:
+        _config.capture.serial_port = new_devices[0].serial_port
+        _config.capture.serial_baud = new_devices[0].serial_baud
 
     devices_list = [_serial_device_dict(d) for d in new_devices]
     yaml_updates: dict = {"serial": devices_list}
+    if new_devices:
+        yaml_updates["serial_port"] = new_devices[0].serial_port
+        yaml_updates["serial_baud"] = new_devices[0].serial_baud
     capture_updates: dict = {}
 
     sources = list(_config.capture.sources or [])

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -376,6 +376,12 @@ def _add_serial_source(coordinator: PipelineCoordinator, config: AppConfig):
         )
     ]
     for dev in devices:
+        if not (dev.serial_port or "").strip():
+            logger.warning(
+                "Skipping serial device with empty port (label=%r)",
+                dev.label,
+            )
+            continue
         coordinator.capture_coordinator.add_source(
             SerialCaptureSource(
                 port=dev.serial_port,

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,12 @@ def _add_serial_source(coordinator: PipelineCoordinator, config) -> None:
         )
     ]
     for dev in devices:
+        if not (dev.serial_port or "").strip():
+            logger.warning(
+                "Skipping serial device with empty port (label=%r)",
+                dev.label,
+            )
+            continue
         coordinator.capture_coordinator.add_source(
             SerialCaptureSource(
                 port=dev.serial_port,

--- a/tests/test_serial_devices_route.py
+++ b/tests/test_serial_devices_route.py
@@ -67,13 +67,24 @@ class SerialDevicesRouteTest(unittest.TestCase):
         save_mock.assert_called_once()
 
     @patch("src.api.routes.system_config_routes.save_section_to_yaml")
-    def test_blank_port_becomes_none(self, save_mock):
+    def test_blank_rows_are_dropped(self, save_mock):
         resp = self.client.put(
             "/api/config/capture/serial-devices",
-            json={"devices": [{"label": "auto", "serial_port": "  "}]},
+            json={
+                "enable_source": True,
+                "devices": [
+                    {"label": "Heltec", "serial_port": "/dev/ttyACM1"},
+                    {"label": "", "serial_port": None},
+                    {"label": "auto", "serial_port": "  "},
+                ],
+            },
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertIsNone(self.config.capture.serial[0].serial_port)
+        self.assertEqual(len(self.config.capture.serial), 1)
+        self.assertEqual(self.config.capture.serial[0].label, "Heltec")
+        self.assertEqual(self.config.capture.serial_port, "/dev/ttyACM1")
+        payload = save_mock.call_args[0][1]
+        self.assertEqual(len(payload["serial"]), 1)
 
     @patch("src.api.routes.system_config_routes.save_section_to_yaml")
     def test_disable_removes_serial_source(self, save_mock):


### PR DESCRIPTION
## Summary
- Drop serial device rows with no port on save (UI leftover Add Device rows)
- Skip empty-port devices when wiring capture sources
- Frontend no longer POSTs blank rows

## Test plan
- [x] pytest serial-devices + multi-serial
- [x] Pi recovered by stripping blank row; dashboard on :8080 again
- [ ] Re-save Configuration → Serial with one Heltec + unused blank row; restart stays up