### PR TITLE
Cache-bust dashboard assets after restart

### DIFF
--- a/src/api/html_assets.py
+++ b/src/api/html_assets.py
@@ -1,0 +1,36 @@
+"""Cache-busting for the dashboard's static JS/CSS asset URLs.
+
+After a dashboard self-update, browsers can keep executing stale cached
+JS against freshly deployed HTML. Features then fail silently until a
+hard reload.
+
+The ``/`` (and auth page) routes rewrite every local ``.js``/``.css`` URL
+to carry a ``?v=<token>`` query. The token is minted once per process;
+every Apply ends in a service restart, so each deploy serves new asset
+URLs. External URLs (http/https/protocol-relative) are left untouched.
+
+Free of FastAPI imports so the rewrite logic unit-tests without the
+full app stack.
+
+Credit: javastraat/meshpoint ``52b6caf``.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+# Per-process token: hex timestamp, minted at import (= service start).
+BOOT_TOKEN = f"{int(time.time()):x}"
+
+# src="..." / href="..." values ending in .js or .css, skipping
+# external URLs (http://, https://, //cdn...). Matches relative
+# ("js/app.js") and root-relative ("/vendor/xterm/xterm.js") paths.
+_ASSET_URL_RE = re.compile(
+    r'((?:src|href)=")(?!https?://|//)([^"?]+\.(?:js|css))(")'
+)
+
+
+def bust_asset_urls(html: str, token: str = BOOT_TOKEN) -> str:
+    """Append ``?v=<token>`` to every local JS/CSS asset URL in *html*."""
+    return _ASSET_URL_RE.sub(rf"\g<1>\g<2>?v={token}\g<3>", html)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from src._so_compat_check import warn_if_stale_so_files
@@ -330,8 +330,9 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         ):
             target = "/login" if auth_subsystem.service.is_setup_complete() else "/setup"
             return RedirectResponse(url=target, status_code=302)
-        return FileResponse(
-            str(static_dir / "index.html"), media_type="text/html"
+        return HTMLResponse(
+            _read_busted_html(static_dir / "index.html"),
+            headers={"Cache-Control": "no-cache"},
         )
 
     if static_dir.exists():
@@ -1495,13 +1496,23 @@ def _request_has_valid_session(
     return jwt_service.verify(token) is not None
 
 
-def _serve_auth_page(static_dir: Path, filename: str) -> FileResponse:
+def _serve_auth_page(static_dir: Path, filename: str) -> HTMLResponse:
     """Return one of the two pre-auth HTML pages from frontend/auth/."""
     page = static_dir / "auth" / filename
     if not page.exists():
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="auth page not found")
-    return FileResponse(str(page), media_type="text/html")
+    return HTMLResponse(
+        _read_busted_html(page),
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+def _read_busted_html(path: Path) -> str:
+    """Load HTML and append ``?v=`` cache-bust tokens to local JS/CSS."""
+    from src.api.html_assets import bust_asset_urls
+
+    return bust_asset_urls(path.read_text(encoding="utf-8"))
 
 
 def _on_packet_received(packet: Packet) -> None:

--- a/tests/test_html_assets.py
+++ b/tests/test_html_assets.py
@@ -1,0 +1,69 @@
+"""Cache-busting asset URL rewriter (no FastAPI required).
+
+Credit: javastraat/meshpoint ``52b6caf``.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.api.html_assets import BOOT_TOKEN, bust_asset_urls
+
+
+class BustAssetUrlsTest(unittest.TestCase):
+    def test_relative_js_and_css_get_the_token(self):
+        html = (
+            '<script src="js/app.js"></script>'
+            '<link rel="stylesheet" href="css/dashboard.css">'
+        )
+        out = bust_asset_urls(html, token="abc123")
+        self.assertIn('src="js/app.js?v=abc123"', out)
+        self.assertIn('href="css/dashboard.css?v=abc123"', out)
+
+    def test_root_relative_vendor_paths_get_the_token(self):
+        html = '<script src="/vendor/xterm/xterm.js"></script>'
+        out = bust_asset_urls(html, token="abc123")
+        self.assertIn('src="/vendor/xterm/xterm.js?v=abc123"', out)
+
+    def test_external_urls_left_untouched(self):
+        html = (
+            '<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>'
+            '<script src="//cdn.example.com/lib.js"></script>'
+            '<link href="http://example.com/style.css">'
+        )
+        self.assertEqual(bust_asset_urls(html, token="abc123"), html)
+
+    def test_non_asset_urls_left_untouched(self):
+        html = (
+            '<img src="/assets/meshpoint-logo.png">'
+            '<a href="/api/device/metrics">metrics</a>'
+        )
+        self.assertEqual(bust_asset_urls(html, token="abc123"), html)
+
+    def test_already_versioned_urls_not_double_tokened(self):
+        html = '<script src="js/app.js?v=old"></script>'
+        self.assertEqual(bust_asset_urls(html, token="new"), html)
+
+    def test_default_token_is_the_boot_token(self):
+        out = bust_asset_urls('<script src="js/a.js"></script>')
+        self.assertIn(f'src="js/a.js?v={BOOT_TOKEN}"', out)
+        self.assertTrue(re.fullmatch(r"[0-9a-f]+", BOOT_TOKEN))
+
+    def test_real_index_html_rewrites_every_local_asset(self):
+        html = Path("frontend/index.html").read_text(encoding="utf-8")
+        out = bust_asset_urls(html, token="t0k")
+        leftovers = re.findall(
+            r'(?:src|href)="(?!https?://|//)[^"?]+\.(?:js|css)"',
+            out,
+        )
+        self.assertEqual(leftovers, [])
+        self.assertEqual(
+            len(re.findall(r'(?:src|href)="https?://[^"]+"', out)),
+            len(re.findall(r'(?:src|href)="https?://[^"]+"', html)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Rewrite local `.js`/`.css` URLs in dashboard and auth HTML with a per-process `?v=` token
- `Cache-Control: no-cache` on those HTML responses so Apply/restart picks up new assets without a hard reload

Rewritten from javastraat/meshpoint (`52b6caf`). Co-authored by Albert Einstein.

## Test plan
- [x] `pytest tests/test_html_assets.py`
- [ ] Hard-refresh optional: View Source on `/` shows `?v=` on local assets, not on unpkg