### PR TITLE
Add max_telemetry_retained storage cleanup

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -44,6 +44,7 @@ capture:
 storage:
   database_path: "data/concentrator.db"
   max_packets_retained: 100000
+  max_telemetry_retained: 100000
   cleanup_interval_seconds: 3600
 
 dashboard:

--- a/frontend/js/configuration/advanced_card.js
+++ b/frontend/js/configuration/advanced_card.js
@@ -27,6 +27,11 @@ class AdvancedConfigCard {
                                    max="10000000" data-storage-max>
                         </label>
                         <label class="cfg-field">
+                            <span class="cfg-field__label">Max telemetry rows retained</span>
+                            <input class="cfg-field__input" type="number" min="1000"
+                                   max="10000000" data-storage-telemetry-max>
+                        </label>
+                        <label class="cfg-field">
                             <span class="cfg-field__label">Cleanup interval (seconds)</span>
                             <input class="cfg-field__input" type="number" min="60" max="86400"
                                    data-storage-cleanup>
@@ -75,6 +80,7 @@ class AdvancedConfigCard {
         const radioAdv = config.radio_advanced || {};
 
         this._setVal('[data-storage-max]', storage.max_packets_retained);
+        this._setVal('[data-storage-telemetry-max]', storage.max_telemetry_retained);
         this._setVal('[data-storage-cleanup]', storage.cleanup_interval_seconds);
         this._setVal('[data-radio-scan-interval]', radioAdv.spectral_scan_interval_seconds);
         this._setVal('[data-radio-sx1261]', radioAdv.sx1261_spi_path || '');
@@ -93,6 +99,9 @@ class AdvancedConfigCard {
         const result = await this._api.put('/api/config/storage', {
             max_packets_retained: Number(
                 this._root.querySelector('[data-storage-max]').value,
+            ),
+            max_telemetry_retained: Number(
+                this._root.querySelector('[data-storage-telemetry-max]').value,
             ),
             cleanup_interval_seconds: Number(
                 this._root.querySelector('[data-storage-cleanup]').value,

--- a/src/api/routes/config_enrichment.py
+++ b/src/api/routes/config_enrichment.py
@@ -33,6 +33,7 @@ def enrich_config_payload(cfg: AppConfig, base: dict) -> dict:
     base["storage"] = {
         "database_path": storage.database_path,
         "max_packets_retained": storage.max_packets_retained,
+        "max_telemetry_retained": storage.max_telemetry_retained,
         "cleanup_interval_seconds": storage.cleanup_interval_seconds,
     }
     base["capture"] = {

--- a/src/api/routes/system_config_routes.py
+++ b/src/api/routes/system_config_routes.py
@@ -33,6 +33,7 @@ def reset_routes() -> None:
 
 class StorageUpdate(BaseModel):
     max_packets_retained: Optional[int] = Field(None, ge=1000, le=10_000_000)
+    max_telemetry_retained: Optional[int] = Field(None, ge=1000, le=10_000_000)
     cleanup_interval_seconds: Optional[int] = Field(None, ge=60, le=86400)
 
 
@@ -85,6 +86,9 @@ async def update_storage(
     if req.max_packets_retained is not None:
         storage.max_packets_retained = req.max_packets_retained
         updates["max_packets_retained"] = req.max_packets_retained
+    if req.max_telemetry_retained is not None:
+        storage.max_telemetry_retained = req.max_telemetry_retained
+        updates["max_telemetry_retained"] = req.max_telemetry_retained
     if req.cleanup_interval_seconds is not None:
         storage.cleanup_interval_seconds = req.cleanup_interval_seconds
         updates["cleanup_interval_seconds"] = req.cleanup_interval_seconds

--- a/src/config.py
+++ b/src/config.py
@@ -142,6 +142,7 @@ class CaptureConfig:
 class StorageConfig:
     database_path: str = "data/concentrator.db"
     max_packets_retained: int = 100_000
+    max_telemetry_retained: int = 100_000
     cleanup_interval_seconds: int = 3600
 
 

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -185,18 +185,28 @@ class PipelineCoordinator:
         )
 
     async def _cleanup_loop(self) -> None:
-        """Periodically prune old packets to keep the DB from growing unbounded."""
+        """Periodically prune old packets and telemetry to bound DB growth."""
         interval = self._config.storage.cleanup_interval_seconds
-        max_retained = self._config.storage.max_packets_retained
+        max_packets = self._config.storage.max_packets_retained
+        max_telemetry = self._config.storage.max_telemetry_retained
         try:
             while self._running:
                 await asyncio.sleep(interval)
-                removed = await self._packet_repo.cleanup_old(max_retained)
+                removed = await self._packet_repo.cleanup_old(max_packets)
                 if removed:
                     logger.info(
                         f" {CYAN}--{RESET} {DIM}CLEANUP{RESET}  "
                         f"pruned {removed} old packets  "
-                        f"{DIM}(max {max_retained}){RESET}"
+                        f"{DIM}(max {max_packets}){RESET}"
+                    )
+                removed_telemetry = await self._telemetry_repo.cleanup_old(
+                    max_telemetry
+                )
+                if removed_telemetry:
+                    logger.info(
+                        f" {CYAN}--{RESET} {DIM}CLEANUP{RESET}  "
+                        f"pruned {removed_telemetry} old telemetry rows  "
+                        f"{DIM}(max {max_telemetry}){RESET}"
                     )
         except asyncio.CancelledError:
             pass

--- a/src/storage/telemetry_repository.py
+++ b/src/storage/telemetry_repository.py
@@ -73,6 +73,25 @@ class TelemetryRepository:
             )
         return [self._row_to_telemetry(r) for r in rows]
 
+    async def get_count(self) -> int:
+        row = await self._db.fetch_one("SELECT COUNT(*) AS cnt FROM telemetry")
+        return int(row["cnt"]) if row else 0
+
+    async def cleanup_old(self, max_retained: int) -> int:
+        """Prune oldest telemetry rows once the table exceeds max_retained."""
+        total = await self.get_count()
+        if total <= max_retained:
+            return 0
+        excess = total - max_retained
+        await self._db.execute(
+            "DELETE FROM telemetry WHERE id IN "
+            "(SELECT id FROM telemetry ORDER BY timestamp ASC LIMIT ?)",
+            (excess,),
+        )
+        await self._db.commit()
+        logger.info("Cleaned up %d old telemetry rows", excess)
+        return excess
+
     @staticmethod
     def _row_to_telemetry(row: dict) -> Telemetry:
         return Telemetry(

--- a/tests/test_telemetry_cleanup.py
+++ b/tests/test_telemetry_cleanup.py
@@ -1,0 +1,70 @@
+"""Telemetry row-count retention (mirrors packet cleanup).
+
+Credit: javastraat/meshpoint ``691dcd5``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from src.models.telemetry import Telemetry
+from src.storage.database import DatabaseManager
+from src.storage.telemetry_repository import TelemetryRepository
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TelemetryCleanupTest(unittest.TestCase):
+    def setUp(self):
+        self.db = DatabaseManager(":memory:")
+        _run(self.db.connect())
+        self.repo = TelemetryRepository(self.db)
+
+    def tearDown(self):
+        _run(self.db.disconnect())
+
+    async def _seed(self, count: int) -> None:
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for i in range(count):
+            await self.repo.insert(
+                Telemetry(
+                    node_id="aabbccdd",
+                    battery_level=50.0,
+                    voltage=3.7,
+                    temperature=20.0 + i,
+                    humidity=None,
+                    barometric_pressure=None,
+                    channel_utilization=None,
+                    air_util_tx=None,
+                    uptime_seconds=i,
+                    timestamp=base + timedelta(minutes=i),
+                )
+            )
+
+    def test_cleanup_noop_when_under_cap(self):
+        _run(self._seed(3))
+        removed = _run(self.repo.cleanup_old(10))
+        self.assertEqual(removed, 0)
+        self.assertEqual(_run(self.repo.get_count()), 3)
+
+    def test_cleanup_prunes_oldest_first(self):
+        _run(self._seed(5))
+        removed = _run(self.repo.cleanup_old(2))
+        self.assertEqual(removed, 3)
+        self.assertEqual(_run(self.repo.get_count()), 2)
+        history = _run(self.repo.get_history("aabbccdd", limit=10))
+        self.assertEqual(len(history), 2)
+        self.assertEqual(history[0].uptime_seconds, 3)
+        self.assertEqual(history[1].uptime_seconds, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `storage.max_telemetry_retained` (default 100000) + cleanup loop prune
- Configuration → Advanced field + GET/PUT config plumbing

Rewritten from javastraat/meshpoint (`691dcd5`). Co-authored by Albert Einstein.

## Test plan
- [x] `pytest tests/test_telemetry_cleanup.py`
- [ ] Advanced card shows telemetry max after pull/restart