### PR TITLE
Viewer write lockdown + channel secret redaction

### DIFF
--- a/src/api/routes/config_routes.py
+++ b/src/api/routes/config_routes.py
@@ -13,9 +13,11 @@ import logging
 import subprocess
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin, require_auth
+from src.api.auth.jwt_session import ROLE_ADMIN, SessionClaims
 from src.api.routes import (
     config_enrichment,
     mqtt_config_routes,
@@ -103,8 +105,12 @@ def _refresh_channel_hash_map() -> None:
 
 
 @router.get("")
-async def get_config():
-    """Full configuration summary for the Radio tab."""
+async def get_config(claims: SessionClaims = Depends(require_auth)):
+    """Full configuration summary for the Radio / Configuration tabs.
+
+    Channel secrets (Meshtastic PSKs, MeshCore keys) are only included
+    for admins; viewer sessions get the same shape with blanked keys.
+    """
     if _config is None:
         raise HTTPException(503, "Config not loaded")
 
@@ -223,7 +229,18 @@ async def get_config():
             for r, d in REGION_DEFAULTS.items()
         ],
     }
-    return config_enrichment.enrich_config_payload(_config, payload)
+    enriched = config_enrichment.enrich_config_payload(_config, payload)
+    if claims.role != ROLE_ADMIN:
+        _redact_channel_secrets(enriched)
+    return enriched
+
+
+def _redact_channel_secrets(payload: dict) -> None:
+    """Blank channel keys in-place for non-admin callers."""
+    for ch in payload.get("channels") or []:
+        ch["psk_b64"] = ""
+    for ck in (payload.get("meshcore") or {}).get("channel_keys") or []:
+        ck["key_hex"] = ""
 
 
 @router.get("/export")
@@ -251,7 +268,10 @@ class TransmitUpdate(BaseModel):
 
 
 @router.put("/transmit")
-async def update_transmit(req: TransmitUpdate):
+async def update_transmit(
+    req: TransmitUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update TX settings. Some changes require a restart."""
     if _config is None:
         raise HTTPException(503, "Config not loaded")
@@ -323,7 +343,10 @@ class IdentityUpdate(BaseModel):
 
 
 @router.put("/identity")
-async def update_identity(req: IdentityUpdate):
+async def update_identity(
+    req: IdentityUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update node identity. node_id changes need restart."""
     if _config is None:
         raise HTTPException(503, "Config not loaded")
@@ -370,7 +393,10 @@ class RadioUpdate(BaseModel):
 
 
 @router.put("/radio")
-async def update_radio(req: RadioUpdate):
+async def update_radio(
+    req: RadioUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update radio settings. Flags restart_required for RX changes."""
     if _config is None:
         raise HTTPException(503, "Config not loaded")
@@ -450,7 +476,10 @@ class ChannelsUpdate(BaseModel):
 
 
 @router.put("/channels")
-async def update_channels(req: ChannelsUpdate):
+async def update_channels(
+    req: ChannelsUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update channel keys. Applies to crypto at runtime (no restart)."""
     if _config is None:
         raise HTTPException(503, "Config not loaded")
@@ -549,7 +578,10 @@ def _normalize_meshcore_channel_entry(name: str, key_hex: str) -> tuple[str, str
 
 
 @router.put("/meshcore/channels")
-async def update_meshcore_channels(req: McChannelsUpdate):
+async def update_meshcore_channels(
+    req: McChannelsUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update MeshCore channel keys (stored as hex). No restart required."""
     if _config is None:
         raise HTTPException(503, "Config not loaded")
@@ -597,7 +629,9 @@ async def update_meshcore_channels(req: McChannelsUpdate):
 
 
 @router.post("/restart")
-async def restart_service():
+async def restart_service(
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Trigger a service restart via systemctl."""
     try:
         subprocess.Popen(  # nosec B603 B607

--- a/src/api/routes/meshcore_config_routes.py
+++ b/src/api/routes/meshcore_config_routes.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
 from src.config import AppConfig, save_section_to_yaml
 
 logger = logging.getLogger(__name__)
@@ -59,7 +61,10 @@ class CompanionNameUpdate(BaseModel):
 
 
 @router.put("/companion-name")
-async def update_companion_name(req: CompanionNameUpdate) -> dict:
+async def update_companion_name(
+    req: CompanionNameUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+) -> dict:
     """Rename the USB companion (CMD_SET_ADVERT_NAME).
 
     Validation lives in :meth:`MeshCoreTxClient.set_companion_name`

--- a/src/api/routes/messages.py
+++ b/src/api/routes/messages.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
 from src.api.message_name_resolver import MessageNameResolver
 from src.config import AppConfig
 from src.storage.message_repository import (
@@ -63,7 +65,10 @@ class SendRequest(BaseModel):
 
 
 @router.post("/send")
-async def send_message(req: SendRequest):
+async def send_message(
+    req: SendRequest,
+    _claims: SessionClaims = Depends(require_admin),
+):
     if _tx_service is None:
         raise HTTPException(503, "Transmit service not available")
     if _message_repo is None:
@@ -110,7 +115,10 @@ async def send_message(req: SendRequest):
 
 
 @router.post("/advert")
-async def send_meshcore_advert(flood: bool = False):
+async def send_meshcore_advert(
+    flood: bool = False,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Broadcast a MeshCore advertisement from the USB companion.
 
     Independent of /send so it bypasses the empty-text validation
@@ -156,7 +164,10 @@ async def mark_conversation_read(node_id: str):
 
 
 @router.delete("/conversation/{node_id:path}")
-async def delete_conversation(node_id: str):
+async def delete_conversation(
+    node_id: str,
+    _claims: SessionClaims = Depends(require_admin),
+):
     if _message_repo is None:
         raise HTTPException(503, "Message storage not available")
     deleted = await _message_repo.delete_conversation(node_id)
@@ -164,7 +175,9 @@ async def delete_conversation(node_id: str):
 
 
 @router.delete("/all")
-async def delete_all_messages():
+async def delete_all_messages(
+    _claims: SessionClaims = Depends(require_admin),
+):
     if _message_repo is None:
         raise HTTPException(503, "Message storage not available")
     deleted = await _message_repo.delete_all_messages()

--- a/src/api/routes/nodeinfo_routes.py
+++ b/src/api/routes/nodeinfo_routes.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
 from src.config import AppConfig, save_section_to_yaml
 
 logger = logging.getLogger(__name__)
@@ -76,7 +78,10 @@ class NodeInfoUpdate(BaseModel):
 
 
 @router.put("")
-async def update_nodeinfo(req: NodeInfoUpdate):
+async def update_nodeinfo(
+    req: NodeInfoUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Update NodeInfo broadcast settings.
 
     ``interval_minutes`` hot-reloads the running broadcaster: the new
@@ -155,7 +160,9 @@ async def update_nodeinfo(req: NodeInfoUpdate):
 
 
 @router.post("/send")
-async def send_nodeinfo_now():
+async def send_nodeinfo_now(
+    _claims: SessionClaims = Depends(require_admin),
+):
     """Trigger an immediate NodeInfo broadcast (the 'Send Now' button).
 
     Returns 503 when the broadcaster isn't running, which can happen

--- a/src/api/routes/position_broadcast_routes.py
+++ b/src/api/routes/position_broadcast_routes.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
 from src.api.routes.broadcast_status import build_broadcast_status
 from src.config import AppConfig, save_section_to_yaml
 
@@ -38,7 +40,10 @@ class PositionBroadcastUpdate(BaseModel):
 
 
 @router.put("")
-async def update_position_broadcast(req: PositionBroadcastUpdate):
+async def update_position_broadcast(
+    req: PositionBroadcastUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     if _config is None:
         raise HTTPException(503, "Config not loaded")
 

--- a/src/api/routes/telemetry_broadcast_routes.py
+++ b/src/api/routes/telemetry_broadcast_routes.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from src.api.auth.dependencies import require_admin
+from src.api.auth.jwt_session import SessionClaims
 from src.api.routes.broadcast_status import build_broadcast_status
 from src.config import AppConfig, save_section_to_yaml
 
@@ -38,7 +40,10 @@ class TelemetryBroadcastUpdate(BaseModel):
 
 
 @router.put("")
-async def update_telemetry_broadcast(req: TelemetryBroadcastUpdate):
+async def update_telemetry_broadcast(
+    req: TelemetryBroadcastUpdate,
+    _claims: SessionClaims = Depends(require_admin),
+):
     if _config is None:
         raise HTTPException(503, "Config not loaded")
 

--- a/tests/auth_test_helpers.py
+++ b/tests/auth_test_helpers.py
@@ -1,0 +1,35 @@
+"""Shared auth overrides for FastAPI TestClient route suites."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from src.api.auth.dependencies import require_admin, require_auth
+from src.api.auth.jwt_session import SessionClaims
+
+
+def override_as_admin(app: FastAPI) -> None:
+    """Satisfy require_auth / require_admin without a real JWT service."""
+
+    async def _admin() -> SessionClaims:
+        return SessionClaims(subject="admin", role="admin", session_version=1)
+
+    app.dependency_overrides[require_admin] = _admin
+    app.dependency_overrides[require_auth] = _admin
+
+
+def override_as_viewer(app: FastAPI) -> None:
+    """Auth as viewer; admin-only deps still return 403."""
+    from fastapi import HTTPException, status
+
+    async def _viewer() -> SessionClaims:
+        return SessionClaims(subject="viewer", role="viewer", session_version=1)
+
+    async def _forbid_admin() -> SessionClaims:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="admin role required",
+        )
+
+    app.dependency_overrides[require_auth] = _viewer
+    app.dependency_overrides[require_admin] = _forbid_admin

--- a/tests/test_broadcast_config_routes.py
+++ b/tests/test_broadcast_config_routes.py
@@ -21,6 +21,8 @@ def _build_app() -> FastAPI:
     app = FastAPI()
     app.include_router(pos_module.router)
     app.include_router(telem_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_channel_hash_resolver.py
+++ b/tests/test_channel_hash_resolver.py
@@ -22,6 +22,8 @@ PRIVATE_PSK_B64 = "wLvS00jm+SlCkdkZ6DRZXvLoqoSgPT+3vh8zX+MJoyQ="
 def _build_config_app() -> FastAPI:
     app = FastAPI()
     app.include_router(config_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_config_transmit_relay.py
+++ b/tests/test_config_transmit_relay.py
@@ -14,6 +14,8 @@ from src.api.routes import config_routes as config_module
 def _build_app() -> FastAPI:
     app = FastAPI()
     app.include_router(config_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_meshcore_channels.py
+++ b/tests/test_meshcore_channels.py
@@ -26,12 +26,16 @@ from src.api.routes import messages as messages_module
 def _build_messages_app() -> FastAPI:
     app = FastAPI()
     app.include_router(messages_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 
 def _build_config_app() -> FastAPI:
     app = FastAPI()
     app.include_router(config_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_meshcore_companion_name_route.py
+++ b/tests/test_meshcore_companion_name_route.py
@@ -35,6 +35,8 @@ class _RenameResult:
 def _build_app() -> FastAPI:
     app = FastAPI()
     app.include_router(mc_routes.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_messages_advert_route.py
+++ b/tests/test_messages_advert_route.py
@@ -27,6 +27,8 @@ class _AdvertResult:
 def _build_app() -> FastAPI:
     app = FastAPI()
     app.include_router(messages_module.router)
+    from tests.auth_test_helpers import override_as_admin
+    override_as_admin(app)
     return app
 
 

--- a/tests/test_viewer_write_lockdown.py
+++ b/tests/test_viewer_write_lockdown.py
@@ -1,0 +1,76 @@
+"""Viewer role cannot mutate config / TX / message write endpoints.
+
+Credit: javastraat/meshpoint ``0c1cd41``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes import config_routes as config_module
+from src.api.routes import messages as messages_module
+from src.config import AppConfig
+from tests.auth_test_helpers import override_as_admin, override_as_viewer
+
+
+class ViewerWriteLockdownTest(unittest.TestCase):
+    def setUp(self):
+        config_module._config = AppConfig()
+        config_module._crypto = None
+        config_module._tx_service = None
+        config_module._serial_sources = []
+        messages_module._tx_service = MagicMock()
+        messages_module._message_repo = MagicMock()
+        messages_module._meshcore_tx = None
+
+        self.admin_app = FastAPI()
+        self.admin_app.include_router(config_module.router)
+        self.admin_app.include_router(messages_module.router)
+        override_as_admin(self.admin_app)
+
+        self.viewer_app = FastAPI()
+        self.viewer_app.include_router(config_module.router)
+        self.viewer_app.include_router(messages_module.router)
+        override_as_viewer(self.viewer_app)
+
+        self.admin = TestClient(self.admin_app)
+        self.viewer = TestClient(self.viewer_app)
+
+    def tearDown(self):
+        config_module._config = None
+        messages_module._tx_service = None
+        messages_module._message_repo = None
+
+    def test_viewer_cannot_put_transmit(self):
+        resp = self.viewer.put("/api/config/transmit", json={"enabled": True})
+        self.assertEqual(resp.status_code, 403)
+
+    def test_viewer_cannot_send_message(self):
+        resp = self.viewer.post(
+            "/api/messages/send",
+            json={"text": "hi", "destination": "broadcast"},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_viewer_config_redacts_channel_secrets(self):
+        cfg = config_module._config
+        cfg.meshtastic.default_key_b64 = "AQ=="
+        cfg.meshtastic.channel_keys = {"Private": "wLvS00jm+SlCkdkZ6DRZXvLoqoSgPT+3vh8zX+MJoyQ="}
+        cfg.meshcore.channel_keys = {"Public": "00" * 16}
+
+        admin_body = self.admin.get("/api/config").json()
+        viewer_body = self.viewer.get("/api/config").json()
+
+        self.assertTrue(any(ch.get("psk_b64") for ch in admin_body["channels"]))
+        self.assertTrue(all(ch.get("psk_b64") == "" for ch in viewer_body["channels"]))
+        self.assertTrue(
+            all(ck.get("key_hex") == "" for ck in viewer_body["meshcore"]["channel_keys"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `require_admin` on config PUTs, restart, NodeInfo/position/telemetry broadcast writes, companion rename, message send/advert/delete
- `GET /api/config` blanks `psk_b64` / MeshCore `key_hex` for non-admins
- Mark-read left open for viewer UX

Rewritten from javastraat/meshpoint (`0c1cd41`). Co-authored by Albert Einstein.

## Test plan
- [x] `pytest` viewer lockdown + updated config/message route suites (68)