### PR TITLE
Group release-notes preview by CHANGELOG categories

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -849,6 +849,21 @@ select.update-field__input option:checked {
     gap: 6px;
 }
 
+.update-release-notes__category {
+    margin-top: 10px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent-cyan);
+    font-weight: 600;
+    border-bottom: 1px solid color-mix(in srgb, var(--accent-cyan) 20%, transparent);
+    padding-bottom: 3px;
+}
+
+.update-release-notes__list > .update-release-notes__category:first-child {
+    margin-top: 0;
+}
+
 .update-release-notes__bullet {
     display: flex;
     flex-direction: column;

--- a/frontend/js/settings/release_notes_view.js
+++ b/frontend/js/settings/release_notes_view.js
@@ -55,9 +55,7 @@ class ReleaseNotesView {
             : "What's new";
         const title = section.header || section.version || 'Release notes';
         const date = section.date ? this._escape(section.date) : '';
-        const bullets = (section.bullets || [])
-            .map((bullet) => this._renderBullet(bullet))
-            .join('');
+        const bullets = this._renderBullets(section.bullets || []);
         const installed = body.current_installed_version
             ? `<p class="update-release-notes__date">Installed: v${this._escape(body.current_installed_version)}</p>`
             : '';
@@ -73,6 +71,22 @@ class ReleaseNotesView {
                 ${bullets || '<li class="update-release-notes__empty">No bullets in this section.</li>'}
             </ul>
         `;
+    }
+
+    _renderBullets(bullets) {
+        const parts = [];
+        let lastCategory = null;
+        for (const bullet of bullets) {
+            const category = (bullet.category || '').trim();
+            if (category && category !== lastCategory) {
+                parts.push(
+                    `<li class="update-release-notes__category">${this._escape(category)}</li>`
+                );
+                lastCategory = category;
+            }
+            parts.push(this._renderBullet(bullet));
+        }
+        return parts.join('');
     }
 
     _renderBullet(bullet) {

--- a/src/api/update/release_notes.py
+++ b/src/api/update/release_notes.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from src.api.update.channels import normalize_channel_id
 
 _HEADER_RE = re.compile(r"^###\s+(?P<body>.+?)\s*$")
+_CATEGORY_RE = re.compile(r"^####\s+(?P<body>.+?)\s*$")
 _VERSION_RE = re.compile(
     r"^v(?P<version>\d+(?:\.\d+){1,3})(?:\s+\((?P<date>[^)]+)\))?$"
 )
@@ -45,10 +46,15 @@ _RC_CHANNEL_VERSION: dict[str, str] = {
 
 @dataclass(frozen=True)
 class ChangelogBullet:
-    """One ``- **headline.** detail`` line in a changelog section."""
+    """One ``- **headline.** detail`` line in a changelog section.
+
+    ``category`` is the nearest preceding ``#### Category`` heading
+    inside the section (None for bullets above the first one).
+    """
 
     headline: str
     detail: str
+    category: str | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -81,22 +87,30 @@ class ChangelogParser:
     def parse_text(text: str) -> list[ChangelogSection]:
         sections: list[ChangelogSection] = []
         current: ChangelogSection | None = None
+        category: str | None = None
         for raw_line in text.splitlines():
             line = raw_line.rstrip("\r")
             header_match = _HEADER_RE.match(line)
             if header_match:
                 current = _section_from_header(header_match.group("body"))
+                category = None
                 if current is not None:
                     sections.append(current)
                 continue
             if current is None:
+                continue
+            category_match = _CATEGORY_RE.match(line)
+            if category_match:
+                category = category_match.group("body").strip()
                 continue
             bullet_match = _BULLET_RE.match(line)
             if bullet_match:
                 headline = bullet_match.group("headline").strip().rstrip(".")
                 detail = bullet_match.group("detail").strip()
                 current.bullets.append(
-                    ChangelogBullet(headline=headline, detail=detail)
+                    ChangelogBullet(
+                        headline=headline, detail=detail, category=category
+                    )
                 )
         return sections
 
@@ -145,6 +159,7 @@ def format_bullet_for_preview(bullet: ChangelogBullet) -> dict:
     return {
         "headline": bullet.headline,
         "detail": sanitize_detail_for_preview(bullet.detail),
+        "category": bullet.category,
     }
 
 

--- a/tests/test_update_release_notes.py
+++ b/tests/test_update_release_notes.py
@@ -95,6 +95,45 @@ class TestChangelogParser(unittest.TestCase):
         self.assertEqual(len(sections), 1)
         self.assertEqual(sections[0].version, "0.6.0")
 
+    def test_category_headings_attach_to_following_bullets(self) -> None:
+        text = (
+            "### v0.7.7 (July 2026)\n\n"
+            "- **Uncategorized lead.** Bullet above any category.\n\n"
+            "#### LoRaWAN sniffing\n\n"
+            "- **Capture.** First categorized bullet.\n"
+            "- **Decoder.** Second bullet, same category.\n\n"
+            "#### Dashboard and UI\n\n"
+            "- **Sidebar.** Bullet in the next category.\n"
+        )
+        sections = ChangelogParser.parse_text(text)
+        bullets = sections[0].bullets
+        self.assertEqual(
+            [b.category for b in bullets],
+            [None, "LoRaWAN sniffing", "LoRaWAN sniffing", "Dashboard and UI"],
+        )
+
+    def test_category_resets_at_next_version_section(self) -> None:
+        text = (
+            "### v0.7.7 (July 2026)\n\n"
+            "#### Roles and access\n\n"
+            "- **Lockdown.** Categorized bullet.\n\n"
+            "### v0.7.6 (June 2026)\n\n"
+            "- **Older bullet.** Must not inherit the previous section's category.\n"
+        )
+        sections = ChangelogParser.parse_text(text)
+        self.assertEqual(sections[0].bullets[0].category, "Roles and access")
+        self.assertIsNone(sections[1].bullets[0].category)
+
+    def test_preview_bullet_carries_category(self) -> None:
+        text = (
+            "### v0.7.7 (July 2026)\n\n"
+            "#### CLI\n\n"
+            "- **Report.** Works again.\n"
+        )
+        section = ChangelogParser.parse_text(text)[0]
+        preview = format_section_for_preview(section)
+        self.assertEqual(preview["bullets"][0]["category"], "CLI")
+
 
 class TestSelectPreviewSection(unittest.TestCase):
     """Channel-tier -> changelog-section dispatch."""


### PR DESCRIPTION
## Summary
- Parse `####` headings into `ChangelogBullet.category`
- Render category rows in Settings → Updates release-notes preview

Rewritten from javastraat/meshpoint (`21803d8`). Co-authored by Albert Einstein.

## Test plan
- [x] `pytest tests/test_update_release_notes.py`