### PR TITLE
List incoming commits when Updates is behind

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -371,6 +371,36 @@
     color: #ff6b6b;
 }
 
+.update-incoming {
+    list-style: none;
+    margin: 0 0 12px;
+    padding: 0;
+    font-family: var(--font-mono, "JetBrains Mono", monospace);
+    font-size: 12px;
+    color: var(--text-secondary, #94a3b8);
+    max-height: 180px;
+    overflow-y: auto;
+}
+
+.update-incoming[hidden] {
+    display: none;
+}
+
+.update-incoming li {
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.12));
+}
+
+.update-incoming code {
+    color: var(--accent-cyan, #22d3ee);
+    margin-right: 6px;
+}
+
+.update-incoming__more {
+    color: var(--text-muted, #64748b);
+    font-style: italic;
+}
+
 .update-rollback-hint {
     margin: 8px 0 0;
     font-size: 12px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -525,6 +525,7 @@
                         <p class="update-sync-status" data-update-sync-hint>
                             Select a channel, then check how far behind GitHub you are.
                         </p>
+                        <ul class="update-incoming" data-update-incoming hidden></ul>
                         <div class="update-card__actions">
                             <button class="terminal-button terminal-button--ghost" type="button" data-update-check>Check for updates</button>
                             <button class="terminal-button terminal-button--primary" type="button" data-update-apply>Apply update</button>
@@ -746,6 +747,7 @@
     <script src="js/settings/update_progress_view.js"></script>
     <script src="js/settings/update_stream_client.js"></script>
     <script src="js/settings/release_notes_view.js"></script>
+    <script src="js/settings/update_incoming_view.js"></script>
     <script src="js/settings/update_panel_controller.js"></script>
     <script src="js/settings/meshpoint_display_form.js"></script>
     <script src="js/settings/backup_restore_card.js"></script>

--- a/frontend/js/settings/update_incoming_view.js
+++ b/frontend/js/settings/update_incoming_view.js
@@ -1,0 +1,45 @@
+/**
+ * Renders incoming commit subjects when the install is behind origin.
+ *
+ * Credit: javastraat/meshpoint ``4ed91d5``.
+ */
+
+class UpdateIncomingView {
+    constructor(rootEl) {
+        this.root = rootEl;
+    }
+
+    clear() {
+        if (!this.root) return;
+        this.root.textContent = '';
+        this.root.hidden = true;
+    }
+
+    render(status) {
+        if (!this.root) return;
+        const commits = (status && status.incoming_commits) || [];
+        const behind = status && status.commits_behind;
+        this.root.textContent = '';
+        if (!behind || !commits.length) {
+            this.root.hidden = true;
+            return;
+        }
+        commits.forEach((c) => {
+            const li = document.createElement('li');
+            const sha = document.createElement('code');
+            sha.textContent = c.sha || '';
+            li.appendChild(sha);
+            li.appendChild(document.createTextNode(` ${c.subject || ''}`));
+            this.root.appendChild(li);
+        });
+        if (behind > commits.length) {
+            const li = document.createElement('li');
+            li.className = 'update-incoming__more';
+            li.textContent = `… and ${behind - commits.length} more`;
+            this.root.appendChild(li);
+        }
+        this.root.hidden = false;
+    }
+}
+
+window.UpdateIncomingView = UpdateIncomingView;

--- a/frontend/js/settings/update_panel_controller.js
+++ b/frontend/js/settings/update_panel_controller.js
@@ -34,6 +34,9 @@ class UpdatePanelController {
         this.rollbackBtn = rootEl.querySelector('[data-update-rollback]');
         this.rollbackHintEl = rootEl.querySelector('[data-update-rollback-hint]');
         this.syncHintEl = rootEl.querySelector('[data-update-sync-hint]');
+        this.incomingView = new window.UpdateIncomingView(
+            rootEl.querySelector('[data-update-incoming]')
+        );
         this.statusEl = rootEl.querySelector('[data-update-status]');
         this.descriptionEl = rootEl.querySelector('[data-update-description]');
         this.localVersionEl = rootEl.querySelector('[data-update-local-version]');
@@ -177,10 +180,12 @@ class UpdatePanelController {
 
     _renderSyncHint(status) {
         if (!this.syncHintEl) return;
+        if (this.incomingView) this.incomingView.render(status);
         if (!status) {
             this.syncHintEl.dataset.kind = '';
             this.syncHintEl.textContent =
                 'Select a channel, then check how far behind GitHub you are.';
+            if (this.incomingView) this.incomingView.clear();
             return;
         }
         if (status.sync_error) {

--- a/src/api/update/install_status.py
+++ b/src/api/update/install_status.py
@@ -307,6 +307,39 @@ def count_commits_behind_ahead(
     return behind, ahead, remote_sha
 
 
+def list_incoming_commits(
+    repo_path: str,
+    branch: str,
+    *,
+    runner: GitRunner = default_git_runner,
+    use_sudo: bool = True,
+    limit: int = 10,
+    timeout_seconds: float = 15.0,
+) -> list[dict]:
+    """Subjects of commits on ``origin/<branch>`` not yet applied locally.
+
+    Newest first. Empty list on any failure.
+    """
+    git = ["sudo", "git"] if use_sudo else ["git"]
+    rc, out, _ = runner(
+        [*git, "log", "--oneline", f"HEAD..origin/{branch}"],
+        repo_path,
+        timeout_seconds,
+    )
+    if rc != 0:
+        return []
+    commits: list[dict] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        sha, _, subject = line.partition(" ")
+        commits.append({"sha": sha, "subject": subject.strip()})
+        if len(commits) >= limit:
+            break
+    return commits
+
+
 def build_install_status_payload(
     *,
     registry: ReleaseChannelRegistry,
@@ -345,6 +378,7 @@ def build_install_status_payload(
     remote_sha_short: Optional[str] = None
     sync_error: Optional[str] = None
     checked_at: Optional[str] = None
+    incoming_commits: list[dict] = []
 
     if sync_remote and compare_branch:
         ok, err = git_fetch_origin_branch(
@@ -358,6 +392,13 @@ def build_install_status_payload(
             commits_ahead = ahead
             remote_sha_short = remote_sha
             checked_at = datetime.now(timezone.utc).isoformat()
+            if behind:
+                incoming_commits = list_incoming_commits(
+                    repo_path,
+                    compare_branch,
+                    runner=runner,
+                    use_sudo=use_sudo,
+                )
         else:
             sync_error = err
 
@@ -392,6 +433,7 @@ def build_install_status_payload(
         "remote_sha_short": remote_sha_short,
         "sync_error": sync_error,
         "checked_at": checked_at,
+        "incoming_commits": incoming_commits,
         "update_available": update_available,
         "rollback_pre_sha": rollback_pre_sha,
         **channel_info,

--- a/tests/test_update_install_status.py
+++ b/tests/test_update_install_status.py
@@ -10,6 +10,7 @@ from src.api.update.channels import ReleaseChannelRegistry
 from src.api.update.install_status import (
     build_install_status_payload,
     count_commits_behind_ahead,
+    list_incoming_commits,
     match_channel_for_branch,
     read_install_git_ref,
     resolve_compare_branch,
@@ -52,7 +53,11 @@ class _FakeGitRunner:
         if "log" in args and "--oneline" in args:
             spec = args[-1]
             if spec.startswith("HEAD.."):
-                return 0, ("ab\n" * self.behind), ""
+                lines = [
+                    f"aaa{i:04d} Incoming commit subject {i}"
+                    for i in range(self.behind)
+                ]
+                return 0, ("\n".join(lines) + "\n"), ""
             if spec.startswith("origin/") and spec.endswith("..HEAD"):
                 return 0, ("cd\n" * self.ahead), ""
         return 1, "", "err"
@@ -174,12 +179,50 @@ class TestBuildInstallStatusPayload(unittest.TestCase):
         self.assertEqual(payload["compare_branch"], "feat/v0.7.8")
         self.assertTrue(payload["update_available"])
         self.assertIsNotNone(payload["checked_at"])
+        self.assertEqual(len(payload["incoming_commits"]), 10)
+        self.assertEqual(
+            payload["incoming_commits"][0]["subject"],
+            "Incoming commit subject 0",
+        )
         self.assertTrue(
             any(len(c) >= 3 and c[:3] == ["git", "fetch", "origin"] for c in runner.calls),
         )
 
+    def test_sync_omits_incoming_when_not_behind(self) -> None:
+        runner = _FakeGitRunner(behind=0)
+        with mock.patch(
+            "src.api.update.install_status.fetch_remote_version_sync",
+            return_value="0.7.4.0",
+        ):
+            with mock.patch(
+                "src.api.update.install_status.__version__",
+                "0.7.4.0",
+            ):
+                payload = build_install_status_payload(
+                    registry=ReleaseChannelRegistry(),
+                    repo_path="/opt/meshpoint",
+                    runner=runner,
+                    use_sudo=False,
+                    sync_remote=True,
+                    channel_id="rc-078",
+                )
+        self.assertEqual(payload["commits_behind"], 0)
+        self.assertEqual(payload["incoming_commits"], [])
 
-class TestRevisionCountFallback(unittest.TestCase):
+
+class TestListIncomingCommits(unittest.TestCase):
+    def test_parses_oneline_subjects_and_respects_limit(self) -> None:
+        runner = _FakeGitRunner(behind=5)
+        commits = list_incoming_commits(
+            "/opt/meshpoint",
+            "feat/v0.7.8",
+            runner=runner,
+            use_sudo=False,
+            limit=3,
+        )
+        self.assertEqual(len(commits), 3)
+        self.assertEqual(commits[0]["sha"], "aaa0000")
+        self.assertEqual(commits[2]["subject"], "Incoming commit subject 2")
     def test_rev_list_denied_uses_git_log(self) -> None:
         runner = _FakeGitRunner(behind=3, ahead=1)
         behind, ahead, _ = count_commits_behind_ahead(


### PR DESCRIPTION
## Summary
- Add `list_incoming_commits` and include `incoming_commits` on install-status when behind origin
- Render subjects under the Updates sync hint via `UpdateIncomingView`
- Cover parsing/limit and payload wiring in unit tests

Port of javastraat/meshpoint `4ed91d5`.

## Test plan
- [x] `python -m pytest tests/test_update_install_status.py`
- [ ] On Pi: Settings → Updates → Check; when behind, confirm commit list appears