### PR TITLE
Show latest origin commits on Updates

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -401,6 +401,53 @@
     font-style: italic;
 }
 
+.update-history {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.12));
+}
+
+.update-history[hidden] {
+    display: none;
+}
+
+.update-history__title {
+    margin: 0 0 8px;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted, #64748b);
+}
+
+.update-history__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.update-history__row {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+    padding: 4px 0;
+    font-size: 12px;
+    color: rgba(243, 244, 246, 0.75);
+}
+
+.update-history__what code {
+    font-family: var(--font-mono, monospace);
+    color: var(--accent-cyan, #06b6d4);
+    margin-right: 4px;
+}
+
+.update-history__when {
+    flex: 0 0 auto;
+    min-width: 7.5em;
+    color: var(--text-muted, #64748b);
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+}
+
 .update-rollback-hint {
     margin: 8px 0 0;
     font-size: 12px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -532,6 +532,10 @@
                             <button class="terminal-button terminal-button--ghost" type="button" data-update-rollback disabled>Roll back last apply</button>
                         </div>
                         <p class="update-rollback-hint" data-update-rollback-hint></p>
+                        <div class="update-history" data-update-commits hidden>
+                            <p class="update-history__title">Latest commits</p>
+                            <ul class="update-history__list" data-update-commits-list></ul>
+                        </div>
                         <p class="update-status" data-update-status aria-live="polite"></p>
                     </article>
                     <section class="update-progress" data-update-progress hidden aria-live="polite"></section>
@@ -748,6 +752,7 @@
     <script src="js/settings/update_stream_client.js"></script>
     <script src="js/settings/release_notes_view.js"></script>
     <script src="js/settings/update_incoming_view.js"></script>
+    <script src="js/settings/update_remote_commits_view.js"></script>
     <script src="js/settings/update_panel_controller.js"></script>
     <script src="js/settings/meshpoint_display_form.js"></script>
     <script src="js/settings/backup_restore_card.js"></script>

--- a/frontend/js/settings/update_panel_controller.js
+++ b/frontend/js/settings/update_panel_controller.js
@@ -37,6 +37,10 @@ class UpdatePanelController {
         this.incomingView = new window.UpdateIncomingView(
             rootEl.querySelector('[data-update-incoming]')
         );
+        this.remoteCommitsView = new window.UpdateRemoteCommitsView(
+            rootEl.querySelector('[data-update-commits]'),
+            rootEl.querySelector('[data-update-commits-list]')
+        );
         this.statusEl = rootEl.querySelector('[data-update-status]');
         this.descriptionEl = rootEl.querySelector('[data-update-description]');
         this.localVersionEl = rootEl.querySelector('[data-update-local-version]');
@@ -96,6 +100,9 @@ class UpdatePanelController {
             if (!response.ok) return;
             this._installStatus = await response.json();
             this._renderVersionCards(this._installStatus);
+            if (this.remoteCommitsView) {
+                this.remoteCommitsView.render(this._installStatus);
+            }
             if (!this._installStatus.checked_at) {
                 this._renderSyncHint(null);
             }
@@ -132,6 +139,9 @@ class UpdatePanelController {
             }
             this._installStatus = await response.json();
             this._renderVersionCards(this._installStatus);
+            if (this.remoteCommitsView) {
+                this.remoteCommitsView.render(this._installStatus);
+            }
             this._renderSyncHint(this._installStatus);
             const behind = this._installStatus.commits_behind;
             if (this._installStatus.sync_error) {

--- a/frontend/js/settings/update_remote_commits_view.js
+++ b/frontend/js/settings/update_remote_commits_view.js
@@ -1,0 +1,65 @@
+/**
+ * Renders the latest commits on origin/<branch> for the Updates card.
+ *
+ * Credit: javastraat/meshpoint ``98577f3``.
+ */
+
+class UpdateRemoteCommitsView {
+    constructor(rootEl, listEl) {
+        this.root = rootEl;
+        this.list = listEl;
+    }
+
+    clear() {
+        if (this.list) this.list.textContent = '';
+        if (this.root) this.root.hidden = true;
+    }
+
+    render(status) {
+        if (!this.root || !this.list) return;
+        const commits = (status && status.remote_commits) || [];
+        this.list.textContent = '';
+        if (!commits.length) {
+            this.root.hidden = true;
+            return;
+        }
+        commits.slice(0, 5).forEach((c) => {
+            const li = document.createElement('li');
+            li.className = 'update-history__row';
+
+            const when = document.createElement('span');
+            when.className = 'update-history__when';
+            when.textContent = this._formatCommitTime(c.committed_at);
+            li.appendChild(when);
+
+            const what = document.createElement('span');
+            what.className = 'update-history__what';
+            const sha = document.createElement('code');
+            sha.textContent = c.sha || '';
+            what.appendChild(sha);
+            what.appendChild(document.createTextNode(` ${c.subject || ''}`));
+            li.appendChild(what);
+
+            this.list.appendChild(li);
+        });
+        this.root.hidden = false;
+    }
+
+    _formatCommitTime(iso) {
+        if (!iso) return '--';
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return '--';
+        try {
+            return d.toLocaleString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+            });
+        } catch (_e) {
+            return d.toISOString().slice(0, 16).replace('T', ' ');
+        }
+    }
+}
+
+window.UpdateRemoteCommitsView = UpdateRemoteCommitsView;

--- a/src/api/update/install_status.py
+++ b/src/api/update/install_status.py
@@ -340,6 +340,50 @@ def list_incoming_commits(
     return commits
 
 
+def list_branch_commits(
+    repo_path: str,
+    ref: str,
+    *,
+    runner: GitRunner = default_git_runner,
+    use_sudo: bool = True,
+    limit: int = 5,
+    timeout_seconds: float = 15.0,
+) -> list[dict]:
+    """Most recent commits at ``ref`` (e.g. ``origin/main``), newest first.
+
+    Empty list on any failure.
+    """
+    git = ["sudo", "git"] if use_sudo else ["git"]
+    rc, out, _ = runner(
+        [*git, "log", "-n", str(limit), "--format=%h%x09%ct%x09%s", ref],
+        repo_path,
+        timeout_seconds,
+    )
+    if rc != 0:
+        return []
+    commits: list[dict] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        sha, _, rest = line.partition("\t")
+        ts_raw, _, subject = rest.partition("\t")
+        try:
+            committed_at = datetime.fromtimestamp(
+                int(ts_raw), tz=timezone.utc,
+            ).isoformat()
+        except (ValueError, OSError, OverflowError):
+            committed_at = None
+        commits.append({
+            "sha": sha,
+            "subject": subject.strip(),
+            "committed_at": committed_at,
+        })
+        if len(commits) >= limit:
+            break
+    return commits
+
+
 def build_install_status_payload(
     *,
     registry: ReleaseChannelRegistry,
@@ -421,6 +465,15 @@ def build_install_status_payload(
     rollback = read_rollback_state(path=rb_path)
     rollback_pre_sha = rollback["pre_update_sha"] if rollback else None
 
+    remote_commits: list[dict] = []
+    if version_branch:
+        remote_commits = list_branch_commits(
+            repo_path,
+            f"origin/{version_branch}",
+            runner=runner,
+            use_sudo=use_sudo,
+        )
+
     return {
         "local_version": __version__,
         "install_branch": branch,
@@ -434,6 +487,7 @@ def build_install_status_payload(
         "sync_error": sync_error,
         "checked_at": checked_at,
         "incoming_commits": incoming_commits,
+        "remote_commits": remote_commits,
         "update_available": update_available,
         "rollback_pre_sha": rollback_pre_sha,
         **channel_info,

--- a/tests/test_update_install_status.py
+++ b/tests/test_update_install_status.py
@@ -10,6 +10,7 @@ from src.api.update.channels import ReleaseChannelRegistry
 from src.api.update.install_status import (
     build_install_status_payload,
     count_commits_behind_ahead,
+    list_branch_commits,
     list_incoming_commits,
     match_channel_for_branch,
     read_install_git_ref,
@@ -60,6 +61,13 @@ class _FakeGitRunner:
                 return 0, ("\n".join(lines) + "\n"), ""
             if spec.startswith("origin/") and spec.endswith("..HEAD"):
                 return 0, ("cd\n" * self.ahead), ""
+        if "log" in args and any(a.startswith("--format=") for a in args):
+            # list_branch_commits: sha\tts\tsubject
+            lines = [
+                f"bbb{i:04d}\t{1700000000 + i}\tRemote tip commit {i}"
+                for i in range(5)
+            ]
+            return 0, ("\n".join(lines) + "\n"), ""
         return 1, "", "err"
 
 
@@ -184,6 +192,11 @@ class TestBuildInstallStatusPayload(unittest.TestCase):
             payload["incoming_commits"][0]["subject"],
             "Incoming commit subject 0",
         )
+        self.assertEqual(len(payload["remote_commits"]), 5)
+        self.assertEqual(
+            payload["remote_commits"][0]["subject"],
+            "Remote tip commit 0",
+        )
         self.assertTrue(
             any(len(c) >= 3 and c[:3] == ["git", "fetch", "origin"] for c in runner.calls),
         )
@@ -223,6 +236,25 @@ class TestListIncomingCommits(unittest.TestCase):
         self.assertEqual(len(commits), 3)
         self.assertEqual(commits[0]["sha"], "aaa0000")
         self.assertEqual(commits[2]["subject"], "Incoming commit subject 2")
+
+
+class TestListBranchCommits(unittest.TestCase):
+    def test_parses_tab_format_with_timestamp(self) -> None:
+        runner = _FakeGitRunner()
+        commits = list_branch_commits(
+            "/opt/meshpoint",
+            "origin/feat/v0.7.8",
+            runner=runner,
+            use_sudo=False,
+            limit=3,
+        )
+        self.assertEqual(len(commits), 3)
+        self.assertEqual(commits[0]["sha"], "bbb0000")
+        self.assertEqual(commits[0]["subject"], "Remote tip commit 0")
+        self.assertTrue(commits[0]["committed_at"].startswith("20"))
+
+
+class TestRevisionCountFallback(unittest.TestCase):
     def test_rev_list_denied_uses_git_log(self) -> None:
         runner = _FakeGitRunner(behind=3, ahead=1)
         behind, ahead, _ = count_commits_behind_ahead(


### PR DESCRIPTION
## Summary
- Add `list_branch_commits` and `remote_commits` on install-status
- Render a Latest commits strip under the rollback hint
- Keep the live apply `UpdateLogView` (fork had replaced a persisted history we do not ship)

Port of javastraat/meshpoint `98577f3` (additive).

## Test plan
- [x] `python -m pytest tests/test_update_install_status.py`
- [ ] On Pi: Check for updates and confirm Latest commits populates