### PR TITLE
Full release-notes modal on Updates

### DIFF
--- a/frontend/css/update_release_notes_modal.css
+++ b/frontend/css/update_release_notes_modal.css
@@ -1,0 +1,73 @@
+/* Full release-notes modal (Updates panel). */
+
+.update-release-notes__more {
+    margin-top: 10px;
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--accent-cyan, #22d3ee);
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.update-release-notes__more:hover {
+    color: var(--text-primary, #e2e8f0);
+}
+
+.rn-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(3, 8, 20, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.rn-modal {
+    background: var(--bg-secondary, #12161f);
+    border: 1px solid var(--border-color, #232a38);
+    border-radius: 12px;
+    width: min(760px, 100%);
+    max-height: 84vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 24px 60px rgba(3, 8, 20, 0.5);
+}
+
+.rn-modal__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color, #232a38);
+}
+
+.rn-modal__title {
+    margin: 0;
+    font-size: 15px;
+    color: var(--text-primary, #e2e8f0);
+}
+
+.rn-modal__close {
+    background: none;
+    border: none;
+    color: var(--text-muted, #64748b);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.rn-modal__close:hover {
+    color: var(--text-primary, #e2e8f0);
+}
+
+.rn-modal__list {
+    margin: 0;
+    padding: 16px 20px;
+    overflow-y: auto;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,6 +36,7 @@
     <link rel="stylesheet" href="css/radio_readout.css" />
     <link rel="stylesheet" href="css/stats.css" />
     <link rel="stylesheet" href="css/settings.css" />
+    <link rel="stylesheet" href="css/update_release_notes_modal.css" />
     <link rel="stylesheet" href="css/configuration.css" />
     <link rel="stylesheet" href="css/gps.css" />
     <link rel="stylesheet" href="css/packet_detail_modal.css" />

--- a/frontend/js/settings/release_notes_view.js
+++ b/frontend/js/settings/release_notes_view.js
@@ -50,6 +50,8 @@ class ReleaseNotesView {
             return;
         }
         const section = body.preview_section;
+        // Full (un-truncated) notes for the "Read full release notes" modal.
+        this._fullSection = body.full_section || null;
         const eyebrow = section.is_unreleased
             ? "What's coming"
             : "What's new";
@@ -58,6 +60,9 @@ class ReleaseNotesView {
         const bullets = this._renderBullets(section.bullets || []);
         const installed = body.current_installed_version
             ? `<p class="update-release-notes__date">Installed: v${this._escape(body.current_installed_version)}</p>`
+            : '';
+        const moreBtn = (this._fullSection && (this._fullSection.bullets || []).length)
+            ? '<button type="button" class="update-release-notes__more" data-rn-more>Read full release notes</button>'
             : '';
         this.root.dataset.state = 'ready';
         this.root.innerHTML = `
@@ -70,7 +75,44 @@ class ReleaseNotesView {
             <ul class="update-release-notes__list">
                 ${bullets || '<li class="update-release-notes__empty">No bullets in this section.</li>'}
             </ul>
+            ${moreBtn}
         `;
+        this.root.querySelector('[data-rn-more]')
+            ?.addEventListener('click', () => this._openFullModal());
+    }
+
+    _openFullModal() {
+        if (!this._fullSection) return;
+        const s = this._fullSection;
+        const title = s.header || s.version || 'Release notes';
+        const overlay = document.createElement('div');
+        overlay.className = 'rn-modal-overlay';
+        overlay.setAttribute('role', 'dialog');
+        overlay.setAttribute('aria-modal', 'true');
+        overlay.setAttribute('aria-label', 'Full release notes');
+        overlay.innerHTML = `
+            <div class="rn-modal">
+                <header class="rn-modal__head">
+                    <h3 class="rn-modal__title">${this._escape(title)}</h3>
+                    <button type="button" class="rn-modal__close" aria-label="Close">&times;</button>
+                </header>
+                <ul class="rn-modal__list update-release-notes__list">
+                    ${this._renderBullets(s.bullets || [])}
+                </ul>
+            </div>
+        `;
+        const close = () => {
+            overlay.remove();
+            document.removeEventListener('keydown', onKey);
+        };
+        const onKey = (e) => { if (e.key === 'Escape') close(); };
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) close();
+        });
+        overlay.querySelector('.rn-modal__close').addEventListener('click', close);
+        document.addEventListener('keydown', onKey);
+        document.body.appendChild(overlay);
+        overlay.querySelector('.rn-modal__close').focus();
     }
 
     _renderBullets(bullets) {

--- a/src/api/routes/update_routes.py
+++ b/src/api/routes/update_routes.py
@@ -39,6 +39,7 @@ from src.api.update.rollback_state import clear_rollback_state, write_rollback_s
 from src.api.update.release_notes import (
     ChangelogParser,
     format_section_for_preview,
+    format_section_full,
     select_preview_section,
 )
 from src.version import __version__ as INSTALLED_VERSION
@@ -166,6 +167,9 @@ async def release_notes(
         "current_installed_version": INSTALLED_VERSION,
         "preview_section": (
             format_section_for_preview(preview) if preview is not None else None
+        ),
+        "full_section": (
+            format_section_full(preview) if preview is not None else None
         ),
     }
 

--- a/src/api/update/release_notes.py
+++ b/src/api/update/release_notes.py
@@ -154,11 +154,29 @@ def sanitize_detail_for_preview(detail: str, *, max_len: int = _PREVIEW_DETAIL_M
     return cut.rstrip(".,;") + "…"
 
 
+def sanitize_detail_full(detail: str) -> str:
+    """De-markdown detail text for the full-notes modal (no truncation)."""
+    if not detail:
+        return ""
+    text = _LINK_RE.sub(r"\1", detail)
+    text = text.replace("`", "")
+    return re.sub(r"\s+", " ", text).strip()
+
+
 def format_bullet_for_preview(bullet: ChangelogBullet) -> dict:
     """Serialize one bullet for the dashboard (truncated detail)."""
     return {
         "headline": bullet.headline,
         "detail": sanitize_detail_for_preview(bullet.detail),
+        "category": bullet.category,
+    }
+
+
+def format_bullet_full(bullet: ChangelogBullet) -> dict:
+    """Serialize one bullet with its full (un-truncated) detail."""
+    return {
+        "headline": bullet.headline,
+        "detail": sanitize_detail_full(bullet.detail),
         "category": bullet.category,
     }
 
@@ -171,6 +189,17 @@ def format_section_for_preview(section: ChangelogSection) -> dict:
         "date": section.date,
         "is_unreleased": section.is_unreleased,
         "bullets": [format_bullet_for_preview(b) for b in section.bullets],
+    }
+
+
+def format_section_full(section: ChangelogSection) -> dict:
+    """Serialize a section with full-text bullets for the modal."""
+    return {
+        "header": section.header,
+        "version": section.version,
+        "date": section.date,
+        "is_unreleased": section.is_unreleased,
+        "bullets": [format_bullet_full(b) for b in section.bullets],
     }
 
 

--- a/tests/test_update_release_notes.py
+++ b/tests/test_update_release_notes.py
@@ -13,7 +13,9 @@ from src.api.update.release_notes import (
     ChangelogParser,
     ChangelogSection,
     format_section_for_preview,
+    format_section_full,
     sanitize_detail_for_preview,
+    sanitize_detail_full,
     select_preview_section,
 )
 
@@ -304,6 +306,31 @@ class TestPreviewFormatting(unittest.TestCase):
         payload = format_section_for_preview(section)
         self.assertEqual(payload["bullets"][0]["detail"], "Brief note.")
         self.assertTrue(payload["bullets"][1]["detail"].endswith("…"))
+
+
+class TestFullFormatting(unittest.TestCase):
+    def test_sanitize_detail_full_keeps_long_text(self) -> None:
+        long = "A" * 300
+        self.assertEqual(sanitize_detail_full(long), long)
+
+    def test_format_section_full_does_not_truncate(self) -> None:
+        from src.api.update.release_notes import ChangelogBullet
+
+        detail = "See [docs](https://example.com) and `code` path. " + ("B" * 200)
+        section = ChangelogSection(
+            header="v0.7.3.1",
+            version="0.7.3.1",
+            date=None,
+            is_unreleased=False,
+            bullets=[ChangelogBullet(headline="Long", detail=detail)],
+        )
+        payload = format_section_full(section)
+        out = payload["bullets"][0]["detail"]
+        self.assertNotIn("…", out)
+        self.assertIn("docs", out)
+        self.assertNotIn("https://", out)
+        self.assertNotIn("`", out)
+        self.assertGreater(len(out), 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `format_section_full` / `sanitize_detail_full` and return `full_section` from `/api/update/release_notes`
- Add Read full release notes button + Escape-dismissable modal
- Modal CSS in its own stylesheet to keep `settings.css` from growing further

Port of javastraat/meshpoint `0b357eb`.

## Test plan
- [x] `python -m pytest tests/test_update_release_notes.py`
- [ ] On Pi: open Updates, click Read full release notes, confirm untruncated text and Escape closes