### PR TITLE
Fix chart downsample dropping newest buckets

### DIFF
--- a/src/storage/packet_repository.py
+++ b/src/storage/packet_repository.py
@@ -81,12 +81,15 @@ class PacketRepository:
             bucket_secs = bucket_seconds(span_row, limit, hours)
             rows = await self._db.fetch_all(
                 """
-                SELECT MIN(timestamp) AS timestamp, AVG(rssi) AS rssi, AVG(snr) AS snr
-                FROM packets
-                WHERE source_id = ? AND rssi IS NOT NULL AND timestamp >= ?
-                GROUP BY CAST(strftime('%s', timestamp) AS INTEGER) / ?
+                SELECT * FROM (
+                    SELECT MIN(timestamp) AS timestamp, AVG(rssi) AS rssi, AVG(snr) AS snr
+                    FROM packets
+                    WHERE source_id = ? AND rssi IS NOT NULL AND timestamp >= ?
+                    GROUP BY CAST(strftime('%s', timestamp) AS INTEGER) / ?
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                )
                 ORDER BY timestamp ASC
-                LIMIT ?
                 """,
                 (source_id, since, bucket_secs, limit),
             )

--- a/src/storage/telemetry_repository.py
+++ b/src/storage/telemetry_repository.py
@@ -68,22 +68,25 @@ class TelemetryRepository:
             bucket_secs = bucket_seconds(span_row, limit, hours)
             rows = await self._db.fetch_all(
                 """
-                SELECT
-                    node_id,
-                    AVG(battery_level) AS battery_level,
-                    AVG(voltage) AS voltage,
-                    AVG(temperature) AS temperature,
-                    AVG(humidity) AS humidity,
-                    AVG(barometric_pressure) AS barometric_pressure,
-                    AVG(channel_utilization) AS channel_utilization,
-                    AVG(air_util_tx) AS air_util_tx,
-                    AVG(uptime_seconds) AS uptime_seconds,
-                    MIN(timestamp) AS timestamp
-                FROM telemetry
-                WHERE node_id = ? AND timestamp >= ?
-                GROUP BY CAST(strftime('%s', timestamp) AS INTEGER) / ?
+                SELECT * FROM (
+                    SELECT
+                        node_id,
+                        AVG(battery_level) AS battery_level,
+                        AVG(voltage) AS voltage,
+                        AVG(temperature) AS temperature,
+                        AVG(humidity) AS humidity,
+                        AVG(barometric_pressure) AS barometric_pressure,
+                        AVG(channel_utilization) AS channel_utilization,
+                        AVG(air_util_tx) AS air_util_tx,
+                        AVG(uptime_seconds) AS uptime_seconds,
+                        MIN(timestamp) AS timestamp
+                    FROM telemetry
+                    WHERE node_id = ? AND timestamp >= ?
+                    GROUP BY CAST(strftime('%s', timestamp) AS INTEGER) / ?
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                )
                 ORDER BY timestamp ASC
-                LIMIT ?
                 """,
                 (node_id, since, bucket_secs, limit),
             )

--- a/tests/test_time_bucket.py
+++ b/tests/test_time_bucket.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 from src.models.telemetry import Telemetry
 from src.storage.database import DatabaseManager
@@ -51,6 +52,8 @@ class TelemetryHistoryBucketTest(unittest.IsolatedAsyncioTestCase):
         await self.db.disconnect()
 
     async def test_hours_path_keeps_newest_when_over_limit(self):
+        # Patch bucket width so 20 one-minute samples become 20 groups;
+        # LIMIT 5 must keep the newest five, not the oldest.
         now = datetime.now(timezone.utc)
         for i in range(20):
             await self.repo.insert(
@@ -60,9 +63,14 @@ class TelemetryHistoryBucketTest(unittest.IsolatedAsyncioTestCase):
                     timestamp=now - timedelta(minutes=19 - i),
                 )
             )
-        rows = await self.repo.get_history("n1", limit=5, hours=24)
-        self.assertLessEqual(len(rows), 5)
-        self.assertGreaterEqual(rows[-1].temperature, 15.0)
+        with mock.patch(
+            "src.storage.telemetry_repository.bucket_seconds",
+            return_value=60,
+        ):
+            rows = await self.repo.get_history("n1", limit=5, hours=24)
+        self.assertEqual(len(rows), 5)
+        self.assertGreaterEqual(min(r.temperature for r in rows), 15.0)
+        self.assertGreaterEqual(rows[-1].temperature, rows[0].temperature)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Telemetry and packet signal history now keep the newest ``limit`` buckets (DESC then ASC) so downsampling cannot silently drop the latest samples
- Harden the unit test by forcing a 60s bucket width so the over-limit case is deterministic

Caught by CI on #113 (`test_hours_path_keeps_newest_when_over_limit`).

## Test plan
- [x] `python -m pytest tests/test_time_bucket.py`