### PR TITLE
feat(mqtt): publish native MapReports for the official Meshtastic map

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -125,6 +125,11 @@ mqtt:
   publish_json: false
   location_precision: "exact"
   homeassistant_discovery: false
+  # Public, unencrypted report for the official Meshtastic map.
+  # Uses the transmit node ID and never sends a packet over LoRa.
+  map_reporting_enabled: false
+  map_report_interval_seconds: 3600
+  map_report_position_precision: 14  # valid range: 12..15
 
 location:
   # Where live GPS fixes come from (skyplot + optional mesh POSITION).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- **Native MQTT MapReport.** Optional, public MapReports publish the configured Meshpoint transmit identity to the official Meshtastic map without using LoRa airtime. Includes one-hour minimum cadence, 12-15 bit position privacy, dashboard controls, and `/2/map/` ServiceEnvelope compatibility. Closes [#115](https://github.com/KMX415/meshpoint/issues/115).
 - **MQTT broker TLS.** Transport TLS (`mqtts`, CA bundle, cert validation) is not implemented on `mqtt_publisher.py` (plain TCP only). Until then use plain port 1883 or a LAN broker without TLS.
 
 ### v0.7.7 (July 2026)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -670,6 +670,9 @@ mqtt:
   publish_json: false            # also publish JSON on /json/ topic
   location_precision: "exact"    # exact | approximate | none
   homeassistant_discovery: false # publish HA auto-discovery configs
+  map_reporting_enabled: false   # opt in to the official Meshtastic map
+  map_report_interval_seconds: 3600
+  map_report_position_precision: 14  # 12..15; 12 is least precise
 ```
 
 ### Transport TLS (not yet available)
@@ -699,6 +702,27 @@ Control how much location detail leaves the device via MQTT:
 | `none` | Location stripped entirely from MQTT messages |
 
 Full-precision location data is always available on the [Meshradar](https://meshradar.io) dashboard regardless of this setting.
+
+### Official Meshtastic MapReport
+
+Meshpoint can publish its own transmit identity to the official Meshtastic
+map. This is independent of forwarding captured packets as an MQTT gateway:
+the MapReport uses `transmit.node_id`, `transmit.long_name`, and
+`transmit.short_name`, not the separately derived MQTT gateway ID.
+
+```yaml
+mqtt:
+  enabled: true
+  map_reporting_enabled: true
+  map_report_interval_seconds: 3600
+  map_report_position_precision: 14
+```
+
+MapReports are public, unencrypted, MQTT-only packets sent to
+`<topic_root>/<region>/2/map/`. They do not consume LoRa airtime. A report is
+only sent when `device.latitude`, `device.longitude`, and `transmit.node_id`
+are available. The interval cannot be shorter than 3600 seconds; position
+precision is limited to 12 through 15 bits, matching Meshtastic firmware.
 
 ### Home Assistant Integration
 
@@ -834,6 +858,9 @@ mqtt:                  # MQTT publishing (off by default)
   publish_json: false
   location_precision: "exact"
   homeassistant_discovery: false
+  map_reporting_enabled: false
+  map_report_interval_seconds: 3600
+  map_report_position_precision: 14
 
 storage:               # local SQLite packet store
   database_path: "data/concentrator.db"

--- a/docs/MQTT-AND-MESHRADAR.md
+++ b/docs/MQTT-AND-MESHRADAR.md
@@ -215,6 +215,29 @@ Choose how much GPS detail leaves the device via MQTT:
 Full-precision location is always available on the Meshradar dashboard
 (if upstream is enabled) regardless of this MQTT setting.
 
+### Official Meshtastic map
+
+The normal MQTT gateway publishes packets captured from other nodes under
+`/2/e/`. To publish the Meshpoint's own configured transmit identity on the
+official Meshtastic map, explicitly enable native MapReport publishing:
+
+```yaml
+mqtt:
+  enabled: true
+  map_reporting_enabled: true
+  map_report_interval_seconds: 3600
+  map_report_position_precision: 14
+```
+
+This publishes a public, unencrypted `MAP_REPORT_APP` ServiceEnvelope to
+`<topic_root>/<region>/2/map/`. The envelope uses `transmit.node_id` as both
+the packet source and gateway ID. It is MQTT-only and does not consume LoRa
+airtime.
+
+Reports require configured `device.latitude`, `device.longitude`, and
+`transmit.node_id`. The minimum interval is one hour. Position precision must
+be between 12 and 15 bits; 12 shares the least precise position.
+
 ### Home Assistant
 
 Enable JSON mirror and HA auto-discovery and the broker will receive

--- a/frontend/js/configuration/mqtt_card.js
+++ b/frontend/js/configuration/mqtt_card.js
@@ -116,6 +116,38 @@ class MqttConfigCard {
                             <span class="cfg-field__label">Use TLS (mqtts)</span>
                         </label>
                     </fieldset>
+                    <fieldset class="cfg-fieldset">
+                        <legend class="cfg-fieldset__legend">Official map</legend>
+                        <label class="cfg-field cfg-field--toggle">
+                            <input type="checkbox" data-mqtt-map-report>
+                            <span class="cfg-field__label">
+                                Publish this Meshpoint on the official Meshtastic map
+                            </span>
+                        </label>
+                        <p class="cfg-field__hint">
+                            Opt-in: publishes the node name and approximate location
+                            as a public, unencrypted MQTT MapReport. No LoRa airtime
+                            is used.
+                        </p>
+                        <div class="cfg-row">
+                            <label class="cfg-field">
+                                <span class="cfg-field__label">Interval (seconds)</span>
+                                <input class="cfg-field__input" type="number"
+                                       min="3600" max="604800" step="60"
+                                       data-mqtt-map-interval>
+                            </label>
+                            <label class="cfg-field">
+                                <span class="cfg-field__label">Position precision</span>
+                                <select class="cfg-field__input"
+                                        data-mqtt-map-precision>
+                                    <option value="12">12 bits (most private)</option>
+                                    <option value="13">13 bits</option>
+                                    <option value="14">14 bits (recommended)</option>
+                                    <option value="15">15 bits (most precise)</option>
+                                </select>
+                            </label>
+                        </div>
+                    </fieldset>
                     <div class="cfg-preview" data-mqtt-previews>
                         <span class="cfg-preview__label">Example topics (LongFast gateway)</span>
                         <code class="cfg-preview__value" data-mqtt-preview-mt>--</code>
@@ -145,6 +177,9 @@ class MqttConfigCard {
         this._json = this._root.querySelector('[data-mqtt-json]');
         this._ha = this._root.querySelector('[data-mqtt-ha]');
         this._tls = this._root.querySelector('[data-mqtt-tls]');
+        this._mapReport = this._root.querySelector('[data-mqtt-map-report]');
+        this._mapInterval = this._root.querySelector('[data-mqtt-map-interval]');
+        this._mapPrecision = this._root.querySelector('[data-mqtt-map-precision]');
         this._previewMt = this._root.querySelector('[data-mqtt-preview-mt]');
         this._previewMc = this._root.querySelector('[data-mqtt-preview-mc]');
         this._previewJson = this._root.querySelector('[data-mqtt-preview-json]');
@@ -202,6 +237,15 @@ class MqttConfigCard {
         if (this._json) this._json.checked = !!mqtt.publish_json;
         if (this._ha) this._ha.checked = !!mqtt.homeassistant_discovery;
         if (this._tls) this._tls.checked = !!mqtt.tls_enabled;
+        if (this._mapReport) {
+            this._mapReport.checked = !!mqtt.map_reporting_enabled;
+        }
+        if (this._mapInterval) {
+            this._mapInterval.value = mqtt.map_report_interval_seconds ?? 3600;
+        }
+        if (this._mapPrecision) {
+            this._mapPrecision.value = mqtt.map_report_position_precision ?? 14;
+        }
         this._renderPreviews(mqtt);
         this._refreshRuntime();
         this._startRuntimePolling();
@@ -339,6 +383,15 @@ class MqttConfigCard {
             publish_json: this._json.checked,
             location_precision: this._locPrecision.value,
             homeassistant_discovery: this._ha.checked,
+            map_reporting_enabled: this._mapReport
+                ? this._mapReport.checked
+                : false,
+            map_report_interval_seconds: Number(
+                this._mapInterval?.value || 3600
+            ),
+            map_report_position_precision: Number(
+                this._mapPrecision?.value || 14
+            ),
             tls_enabled: this._tls ? this._tls.checked : false,
             tls_ca_cert: '',
         };

--- a/src/api/routes/mqtt_config_routes.py
+++ b/src/api/routes/mqtt_config_routes.py
@@ -61,6 +61,7 @@ def build_mqtt_runtime_status(
         "last_connect_rc": None,
         "last_disconnect_rc": None,
         "last_publish_at": None,
+        "last_map_report_at": None,
         "connected_since": None,
         "topic_prefix": None,
         "gateway_id": _resolve_gateway_id(mqtt.gateway_id, "meshpoint"),
@@ -91,6 +92,9 @@ def build_mqtt_status(mqtt: MqttConfig, device_name: str) -> dict:
         "publish_json": mqtt.publish_json,
         "location_precision": mqtt.location_precision,
         "homeassistant_discovery": mqtt.homeassistant_discovery,
+        "map_reporting_enabled": mqtt.map_reporting_enabled,
+        "map_report_interval_seconds": mqtt.map_report_interval_seconds,
+        "map_report_position_precision": mqtt.map_report_position_precision,
         "tls_enabled": mqtt.tls_enabled,
         "tls_ca_cert": mqtt.tls_ca_cert or "",
         "topic_preview_meshtastic": _topic_example(
@@ -127,6 +131,9 @@ class MqttUpdate(BaseModel):
     publish_json: bool = False
     location_precision: Literal["exact", "approximate", "none"] = "exact"
     homeassistant_discovery: bool = False
+    map_reporting_enabled: bool = False
+    map_report_interval_seconds: int = Field(3600, ge=3600, le=604800)
+    map_report_position_precision: int = Field(14, ge=12, le=15)
     tls_enabled: bool = False
     tls_ca_cert: str = ""
 
@@ -204,6 +211,9 @@ async def update_mqtt(
         "publish_json": req.publish_json,
         "location_precision": req.location_precision,
         "homeassistant_discovery": req.homeassistant_discovery,
+        "map_reporting_enabled": req.map_reporting_enabled,
+        "map_report_interval_seconds": req.map_report_interval_seconds,
+        "map_report_position_precision": req.map_report_position_precision,
         "gateway_id": gateway_override or None,
         "tls_enabled": req.tls_enabled,
         "tls_ca_cert": req.tls_ca_cert.strip(),
@@ -235,6 +245,13 @@ async def update_mqtt(
         mqtt.publish_json = updates["publish_json"]
         mqtt.location_precision = updates["location_precision"]
         mqtt.homeassistant_discovery = updates["homeassistant_discovery"]
+        mqtt.map_reporting_enabled = updates["map_reporting_enabled"]
+        mqtt.map_report_interval_seconds = updates[
+            "map_report_interval_seconds"
+        ]
+        mqtt.map_report_position_precision = updates[
+            "map_report_position_precision"
+        ]
         mqtt.gateway_id = updates["gateway_id"]
         mqtt.tls_enabled = updates["tls_enabled"]
         mqtt.tls_ca_cert = updates["tls_ca_cert"]
@@ -248,13 +265,15 @@ async def update_mqtt(
 
     device_name = _config.device.device_name or "meshpoint"
     logger.info(
-        "MQTT config updated: enabled=%s broker=%s:%s channels=%s json=%s ha=%s",
+        "MQTT config updated: enabled=%s broker=%s:%s channels=%s "
+        "json=%s ha=%s map=%s",
         req.enabled,
         broker,
         req.broker_port,
         len(req.publish_channels),
         req.publish_json,
         req.homeassistant_discovery,
+        req.map_reporting_enabled,
     )
 
     return {

--- a/src/config.py
+++ b/src/config.py
@@ -199,6 +199,11 @@ class MqttConfig:
     publish_json: bool = False
     location_precision: str = "exact"
     homeassistant_discovery: bool = False
+    # Publish this Meshpoint's own identity to the official Meshtastic map.
+    # Map reports are public, unencrypted, MQTT-only packets.
+    map_reporting_enabled: bool = False
+    map_report_interval_seconds: int = 3600
+    map_report_position_precision: int = 14
 
 
 @dataclass

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -264,9 +264,10 @@ class PipelineCoordinator:
                 logger.exception("Location update callback failed")
 
     async def _map_report_loop(self) -> None:
-        """Publish immediately when connected, then at most once per hour."""
+        """Publish immediately when connected, then at most once per configured interval (min 3600s)."""
         configured = int(self._config.mqtt.map_report_interval_seconds or 3600)
         interval = max(3600, configured)
+        retry = min(300, interval)
         if configured < 3600:
             logger.warning(
                 "mqtt.map_report_interval_seconds=%d is below the "
@@ -278,7 +279,7 @@ class PipelineCoordinator:
             while self._running:
                 if self._mqtt and self._mqtt.connected:
                     published = await self._publish_map_report()
-                    await asyncio.sleep(interval if published else 30)
+                    await asyncio.sleep(interval if published else retry)
                 else:
                     await asyncio.sleep(5)
         except asyncio.CancelledError:

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -14,6 +14,8 @@ from src.decode.packet_router import PacketRouter
 from src.hal.location import LocationSource, build_location_source
 from src.log_format import CYAN, DIM, GREEN, RESET
 from src.models.packet import Packet, Protocol, RawCapture
+from src.radio.presets import MODEM_PRESETS, REGION_DEFAULTS, preset_from_params
+from src.relay.map_report import MapReportData
 from src.relay.meshtastic_transmitter import MeshtasticTransmitter
 from src.relay.mqtt_publisher import MqttPublisher
 from src.relay.relay_manager import RelayManager
@@ -70,6 +72,7 @@ class PipelineCoordinator:
         self._pipeline_task: Optional[asyncio.Task] = None
         self._cleanup_task: Optional[asyncio.Task] = None
         self._location_refresh_task: Optional[asyncio.Task] = None
+        self._map_report_task: Optional[asyncio.Task] = None
         self._last_live_lat: Optional[float] = None
         self._last_live_lon: Optional[float] = None
         self._last_live_alt: Optional[float] = None
@@ -155,6 +158,10 @@ class PipelineCoordinator:
         self._location_refresh_task = asyncio.create_task(
             self._location_refresh_loop(), name="location-refresh"
         )
+        if self._config.mqtt.map_reporting_enabled and self._mqtt:
+            self._map_report_task = asyncio.create_task(
+                self._map_report_loop(), name="mqtt-map-report"
+            )
         registered = [src.name for src in self._capture._sources]
         sources = ", ".join(
             _SOURCE_LABELS.get(s, s) for s in registered
@@ -167,7 +174,12 @@ class PipelineCoordinator:
     async def stop(self) -> None:
         self._running = False
         await self._capture.stop()
-        for task in (self._pipeline_task, self._cleanup_task, self._location_refresh_task):
+        for task in (
+            self._pipeline_task,
+            self._cleanup_task,
+            self._location_refresh_task,
+            self._map_report_task,
+        ):
             if task:
                 task.cancel()
                 try:
@@ -250,6 +262,90 @@ class PipelineCoordinator:
                 cb(lat, lon, alt)
             except Exception:
                 logger.exception("Location update callback failed")
+
+    async def _map_report_loop(self) -> None:
+        """Publish immediately when connected, then at most once per hour."""
+        configured = int(self._config.mqtt.map_report_interval_seconds or 3600)
+        interval = max(3600, configured)
+        if configured < 3600:
+            logger.warning(
+                "mqtt.map_report_interval_seconds=%d is below the "
+                "Meshtastic minimum; using 3600",
+                configured,
+            )
+
+        try:
+            while self._running:
+                if self._mqtt and self._mqtt.connected:
+                    published = await self._publish_map_report()
+                    await asyncio.sleep(interval if published else 30)
+                else:
+                    await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("MQTT map report loop crashed")
+
+    async def _publish_map_report(self) -> bool:
+        mqtt = self._mqtt
+        node_id = self._config.transmit.node_id
+        latitude = self._config.device.latitude
+        longitude = self._config.device.longitude
+        if not mqtt or node_id is None:
+            logger.warning(
+                "MQTT map report skipped: transmit.node_id is not configured"
+            )
+            return False
+        if (
+            latitude is None
+            or longitude is None
+            or (latitude == 0 and longitude == 0)
+        ):
+            logger.warning(
+                "MQTT map report skipped: device latitude/longitude unavailable"
+            )
+            return False
+
+        radio = self._config.radio
+        preset_name = preset_from_params(
+            radio.spreading_factor,
+            radio.bandwidth_khz,
+            radio.coding_rate,
+        ) or "LONG_FAST"
+        preset = MODEM_PRESETS.get(preset_name)
+        expected_name = preset.display_name if preset else "LongFast"
+        expected_frequency = REGION_DEFAULTS.get(
+            radio.region, {}
+        ).get("frequency_mhz")
+        primary_channel = (
+            self._config.meshtastic.primary_channel_name or expected_name
+        )
+        has_default_channel = (
+            self._config.meshtastic.default_key_b64 == "AQ=="
+            and primary_channel.lower() == expected_name.lower()
+            and expected_frequency is not None
+            and radio.frequency_mhz is not None
+            and abs(float(radio.frequency_mhz) - expected_frequency) < 0.0001
+        )
+        online_nodes = await self.node_repo.get_active_count(
+            hours=2, protocol="meshtastic"
+        )
+        report = MapReportData(
+            node_id=node_id,
+            long_name=self._config.transmit.long_name,
+            short_name=self._config.transmit.short_name,
+            latitude=latitude,
+            longitude=longitude,
+            altitude=self._config.device.altitude,
+            firmware_version=self._config.device.firmware_version,
+            region=radio.region,
+            modem_preset=preset_name,
+            primary_channel_name=primary_channel,
+            has_default_channel=has_default_channel,
+            num_online_local_nodes=online_nodes,
+            position_precision=self._config.mqtt.map_report_position_precision,
+        )
+        return mqtt.publish_map_report(report)
 
     async def _run_pipeline(self) -> None:
         try:

--- a/src/relay/map_report.py
+++ b/src/relay/map_report.py
@@ -1,0 +1,124 @@
+"""Native Meshtastic MQTT map-report construction.
+
+Map reports are synthetic MQTT-only packets. They are never transmitted over
+LoRa, and they deliberately use the configured Meshpoint node identity rather
+than the separate MQTT gateway identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.relay.mqtt_formatter import MqttMessage, _build_topic_prefix
+
+MAP_REPORT_PORTNUM = 73
+BROADCAST_NODE_ID = 0xFFFFFFFF
+MIN_POSITION_PRECISION = 12
+MAX_POSITION_PRECISION = 15
+DEFAULT_POSITION_PRECISION = 14
+
+
+@dataclass(frozen=True)
+class MapReportData:
+    """Values published in a Meshtastic ``MapReport`` protobuf."""
+
+    node_id: int
+    long_name: str
+    short_name: str
+    latitude: float
+    longitude: float
+    altitude: float | None
+    firmware_version: str
+    region: str
+    modem_preset: str
+    primary_channel_name: str
+    has_default_channel: bool
+    num_online_local_nodes: int = 0
+    position_precision: int = DEFAULT_POSITION_PRECISION
+    role: int = 0
+    hw_model: int = 37
+
+
+def build_map_report_message(
+    data: MapReportData,
+    *,
+    topic_root: str,
+    mqtt_region: str,
+) -> MqttMessage:
+    """Build the official ``ServiceEnvelope`` published on ``/2/map/``."""
+    from meshtastic.protobuf import mesh_pb2, mqtt_pb2
+
+    precision = max(
+        MIN_POSITION_PRECISION,
+        min(int(data.position_precision), MAX_POSITION_PRECISION),
+    )
+    node_id = int(data.node_id) & 0xFFFFFFFF
+    node_id_text = f"!{node_id:08x}"
+
+    report = mqtt_pb2.MapReport()
+    report.long_name = data.long_name[:24]
+    report.short_name = data.short_name[:4]
+    report.role = int(data.role)
+    report.hw_model = int(data.hw_model)
+    report.firmware_version = data.firmware_version[:17]
+    report.region = _enum_value(
+        "meshtastic.protobuf.config_pb2",
+        "Config.LoRaConfig.RegionCode",
+        data.region,
+    )
+    report.modem_preset = _enum_value(
+        "meshtastic.protobuf.config_pb2",
+        "Config.LoRaConfig.ModemPreset",
+        data.modem_preset,
+    )
+    report.has_default_channel = bool(data.has_default_channel)
+    report.latitude_i = _round_coordinate(data.latitude, precision)
+    report.longitude_i = _round_coordinate(data.longitude, precision)
+    if data.altitude is not None:
+        report.altitude = int(data.altitude)
+    report.position_precision = precision
+    report.num_online_local_nodes = max(
+        0, min(int(data.num_online_local_nodes), 0xFFFF)
+    )
+    report.has_opted_report_location = True
+
+    mesh_packet = mesh_pb2.MeshPacket()
+    setattr(mesh_packet, "from", node_id)
+    mesh_packet.to = BROADCAST_NODE_ID
+    mesh_packet.decoded.portnum = MAP_REPORT_PORTNUM
+    mesh_packet.decoded.payload = report.SerializeToString()
+
+    envelope = mqtt_pb2.ServiceEnvelope()
+    envelope.packet.CopyFrom(mesh_packet)
+    envelope.channel_id = data.primary_channel_name
+    envelope.gateway_id = node_id_text
+
+    prefix = _build_topic_prefix(topic_root, mqtt_region)
+    return MqttMessage(
+        topic=f"{prefix}/2/map/",
+        payload=envelope.SerializeToString(),
+    )
+
+
+def _round_coordinate(degrees: float, precision: int) -> int:
+    """Match the bit masking and half-step offset used by Meshtastic firmware."""
+    value = int(float(degrees) * 1e7)
+    unsigned = value & 0xFFFFFFFF
+    mask = (0xFFFFFFFF << (32 - precision)) & 0xFFFFFFFF
+    rounded = ((unsigned & mask) + (1 << (31 - precision))) & 0xFFFFFFFF
+    if rounded >= 0x80000000:
+        return rounded - 0x100000000
+    return rounded
+
+
+def _enum_value(module_name: str, enum_path: str, name: str) -> int:
+    """Resolve generated protobuf enum names without hard-coded numbers."""
+    from importlib import import_module
+
+    value = import_module(module_name)
+    for part in enum_path.split("."):
+        value = getattr(value, part)
+    try:
+        return int(value.Value(name))
+    except ValueError:
+        return 0

--- a/src/relay/mqtt_publisher.py
+++ b/src/relay/mqtt_publisher.py
@@ -19,6 +19,7 @@ from typing import Optional
 from src.config import MqttConfig
 from src.models.packet import Packet, PacketType, Protocol
 from src.relay.channel_resolver import ChannelResolver
+from src.relay.map_report import MapReportData, build_map_report_message
 from src.relay.mqtt_formatter import (
     MeshCoreMqttFormatter,
     MeshtasticMqttFormatter,
@@ -60,6 +61,7 @@ class MqttPublisher:
         self._last_connect_rc: int | None = None
         self._last_disconnect_rc: int | None = None
         self._last_publish_monotonic: float | None = None
+        self._last_map_report_monotonic: float | None = None
         self._connected_since_monotonic: float | None = None
 
         self._allowed_channels = set(
@@ -105,6 +107,9 @@ class MqttPublisher:
             "last_connect_rc": self._last_connect_rc,
             "last_disconnect_rc": self._last_disconnect_rc,
             "last_publish_at": _iso_from_monotonic(self._last_publish_monotonic),
+            "last_map_report_at": _iso_from_monotonic(
+                self._last_map_report_monotonic
+            ),
             "connected_since": _iso_from_monotonic(self._connected_since_monotonic),
             "topic_prefix": self._topic_prefix,
             "gateway_id": self._gateway_id,
@@ -192,6 +197,38 @@ class MqttPublisher:
                 self._ha_discovery.publish_state(packet)
 
         return published
+
+    def publish_map_report(self, report: MapReportData) -> bool:
+        """Publish this Meshpoint's opt-in, MQTT-only map report."""
+        if not self._connected or not self._client:
+            return False
+
+        try:
+            message = build_map_report_message(
+                report,
+                topic_root=self._config.topic_root,
+                mqtt_region=self._config.region,
+            )
+            result = self._client.publish(
+                message.topic, message.payload, qos=1
+            )
+        except Exception:
+            logger.exception("MQTT map report build/publish failed")
+            return False
+
+        if result.rc != paho_mqtt.MQTT_ERR_SUCCESS:
+            logger.warning("MQTT map report publish failed rc=%d", result.rc)
+            return False
+
+        self._publish_count += 1
+        self._last_publish_monotonic = time.monotonic()
+        self._last_map_report_monotonic = self._last_publish_monotonic
+        logger.info(
+            "MQTT map report published for !%08x to %s",
+            report.node_id & 0xFFFFFFFF,
+            message.topic,
+        )
+        return True
 
     def _passes_safety_gates(self, packet: Packet) -> bool:
         if packet.packet_type == PacketType.ENCRYPTED:

--- a/src/storage/node_repository.py
+++ b/src/storage/node_repository.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
-
-from datetime import timedelta
 
 from src.models.node import Node
 from src.storage.database import DatabaseManager
@@ -86,11 +84,16 @@ class NodeRepository:
         row = await self._db.fetch_one("SELECT COUNT(*) as cnt FROM nodes")
         return row["cnt"] if row else 0
 
-    async def get_active_count(self, hours: int = 24) -> int:
+    async def get_active_count(
+        self, hours: int = 24, protocol: str | None = None
+    ) -> int:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
-        row = await self._db.fetch_one(
-            "SELECT COUNT(*) as cnt FROM nodes WHERE last_heard >= ?", (cutoff,)
-        )
+        query = "SELECT COUNT(*) as cnt FROM nodes WHERE last_heard >= ?"
+        params: tuple = (cutoff,)
+        if protocol:
+            query += " AND protocol = ?"
+            params += (protocol,)
+        row = await self._db.fetch_one(query, params)
         return row["cnt"] if row else 0
 
     async def get_with_position(self) -> list[Node]:

--- a/tests/test_map_report.py
+++ b/tests/test_map_report.py
@@ -1,0 +1,155 @@
+"""Tests for native, MQTT-only Meshtastic MapReport publishing."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from meshtastic.protobuf import mqtt_pb2
+
+from src.config import AppConfig, MqttConfig
+from src.coordinator import PipelineCoordinator
+from src.relay.map_report import (
+    MAP_REPORT_PORTNUM,
+    MapReportData,
+    _round_coordinate,
+    build_map_report_message,
+)
+from src.relay.mqtt_publisher import MqttPublisher
+
+
+def _report(**overrides) -> MapReportData:
+    values = {
+        "node_id": 0x5F8FF3B0,
+        "long_name": "Meshpoint2_SCM_KA",
+        "short_name": "SCMK",
+        "latitude": 48.933946,
+        "longitude": 8.570711,
+        "altitude": 180,
+        "firmware_version": "0.7.7",
+        "region": "EU_868",
+        "modem_preset": "LONG_FAST",
+        "primary_channel_name": "LongFast",
+        "has_default_channel": True,
+        "num_online_local_nodes": 3,
+        "position_precision": 14,
+    }
+    values.update(overrides)
+    return MapReportData(**values)
+
+
+class TestMapReportFormat(unittest.TestCase):
+    def test_builds_official_map_topic_and_service_envelope(self) -> None:
+        message = build_map_report_message(
+            _report(), topic_root="msh", mqtt_region="EU"
+        )
+        self.assertEqual(message.topic, "msh/EU/2/map/")
+
+        envelope = mqtt_pb2.ServiceEnvelope()
+        envelope.ParseFromString(message.payload)
+        self.assertEqual(envelope.gateway_id, "!5f8ff3b0")
+        self.assertEqual(envelope.channel_id, "LongFast")
+        self.assertEqual(getattr(envelope.packet, "from"), 0x5F8FF3B0)
+        self.assertEqual(envelope.packet.to, 0xFFFFFFFF)
+        self.assertEqual(envelope.packet.decoded.portnum, MAP_REPORT_PORTNUM)
+
+        report = mqtt_pb2.MapReport()
+        report.ParseFromString(envelope.packet.decoded.payload)
+        self.assertEqual(report.long_name, "Meshpoint2_SCM_KA")
+        self.assertEqual(report.short_name, "SCMK")
+        self.assertEqual(report.hw_model, 37)
+        self.assertEqual(report.firmware_version, "0.7.7")
+        self.assertEqual(report.position_precision, 14)
+        self.assertEqual(report.num_online_local_nodes, 3)
+        self.assertTrue(report.has_default_channel)
+        self.assertTrue(report.has_opted_report_location)
+        self.assertEqual(report.latitude_i, _round_coordinate(48.933946, 14))
+        self.assertEqual(report.longitude_i, _round_coordinate(8.570711, 14))
+
+    def test_bounds_strings_and_position_precision(self) -> None:
+        message = build_map_report_message(
+            _report(
+                long_name="x" * 40,
+                short_name="abcdef",
+                firmware_version="v" * 30,
+                position_precision=99,
+            ),
+            topic_root="msh",
+            mqtt_region="US",
+        )
+        envelope = mqtt_pb2.ServiceEnvelope()
+        envelope.ParseFromString(message.payload)
+        report = mqtt_pb2.MapReport()
+        report.ParseFromString(envelope.packet.decoded.payload)
+        self.assertEqual(len(report.long_name), 24)
+        self.assertEqual(len(report.short_name), 4)
+        self.assertEqual(len(report.firmware_version), 17)
+        self.assertEqual(report.position_precision, 15)
+
+    def test_negative_coordinate_rounding_stays_signed(self) -> None:
+        rounded = _round_coordinate(-74.0060, 14)
+        self.assertLess(rounded, 0)
+        self.assertGreaterEqual(rounded, -(2**31))
+
+
+class TestMapReportPublisher(unittest.TestCase):
+    def test_publish_uses_qos_one_and_tracks_runtime(self) -> None:
+        publisher = MqttPublisher(
+            MqttConfig(enabled=True), device_name="gateway"
+        )
+        client = MagicMock()
+        client.publish.return_value.rc = 0
+        publisher._client = client
+        publisher._connected = True
+
+        self.assertTrue(publisher.publish_map_report(_report()))
+        _, kwargs = client.publish.call_args
+        self.assertEqual(kwargs["qos"], 1)
+        self.assertEqual(publisher.publish_count, 1)
+        self.assertIsNotNone(
+            publisher.get_runtime_status()["last_map_report_at"]
+        )
+
+
+class TestCoordinatorMapReport(unittest.IsolatedAsyncioTestCase):
+    async def test_builds_report_from_meshpoint_config(self) -> None:
+        config = AppConfig()
+        config.device.latitude = 48.933946
+        config.device.longitude = 8.570711
+        config.device.altitude = 180
+        config.radio.region = "EU_868"
+        config.radio.frequency_mhz = 869.525
+        config.transmit.node_id = 0x5F8FF3B0
+        config.transmit.long_name = "Meshpoint2_SCM_KA"
+        config.transmit.short_name = "SCMK"
+        config.mqtt.map_reporting_enabled = True
+
+        coordinator = PipelineCoordinator(config)
+        coordinator._node_repo = MagicMock()
+        coordinator._node_repo.get_active_count = AsyncMock(return_value=4)
+        coordinator._mqtt = MagicMock()
+        coordinator._mqtt.publish_map_report.return_value = True
+
+        self.assertTrue(await coordinator._publish_map_report())
+        report = coordinator._mqtt.publish_map_report.call_args.args[0]
+        self.assertEqual(report.node_id, 0x5F8FF3B0)
+        self.assertEqual(report.region, "EU_868")
+        self.assertEqual(report.modem_preset, "LONG_FAST")
+        self.assertTrue(report.has_default_channel)
+        self.assertEqual(report.num_online_local_nodes, 4)
+        coordinator._node_repo.get_active_count.assert_awaited_once_with(
+            hours=2, protocol="meshtastic"
+        )
+
+    async def test_skips_report_without_location(self) -> None:
+        config = AppConfig()
+        config.transmit.node_id = 0x5F8FF3B0
+        coordinator = PipelineCoordinator(config)
+        coordinator._mqtt = MagicMock()
+
+        self.assertFalse(await coordinator._publish_map_report())
+        coordinator._mqtt.publish_map_report.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mqtt_config_routes.py
+++ b/tests/test_mqtt_config_routes.py
@@ -51,6 +51,9 @@ class TestBuildMqttStatus(unittest.TestCase):
             publish_channels=["LongFast", "MyPrivate"],
             location_precision="approximate",
             homeassistant_discovery=True,
+            map_reporting_enabled=True,
+            map_report_interval_seconds=7200,
+            map_report_position_precision=13,
         )
         status = mqtt_module.build_mqtt_status(mqtt, "My Meshpoint")
         self.assertTrue(status["enabled"])
@@ -61,6 +64,9 @@ class TestBuildMqttStatus(unittest.TestCase):
         self.assertEqual(status["publish_channels"], ["LongFast", "MyPrivate"])
         self.assertEqual(status["location_precision"], "approximate")
         self.assertTrue(status["homeassistant_discovery"])
+        self.assertTrue(status["map_reporting_enabled"])
+        self.assertEqual(status["map_report_interval_seconds"], 7200)
+        self.assertEqual(status["map_report_position_precision"], 13)
         self.assertTrue(status["gateway_id"].startswith("!"))
         self.assertIn("/2/e/", status["topic_preview_meshtastic"])
 
@@ -91,6 +97,9 @@ class TestUpdateMqttRoute(unittest.TestCase):
                     "publish_json": False,
                     "location_precision": "none",
                     "homeassistant_discovery": False,
+                    "map_reporting_enabled": True,
+                    "map_report_interval_seconds": 7200,
+                    "map_report_position_precision": 14,
                 },
             )
         self.assertEqual(resp.status_code, 200)
@@ -104,7 +113,27 @@ class TestUpdateMqttRoute(unittest.TestCase):
         self.assertEqual(saved["broker"], "mqtt.example.com")
         self.assertEqual(saved["region"], "ANZ")
         self.assertFalse(saved["publish_json"])
+        self.assertTrue(saved["map_reporting_enabled"])
+        self.assertEqual(saved["map_report_interval_seconds"], 7200)
+        self.assertEqual(saved["map_report_position_precision"], 14)
         self.assertEqual(saved["password"], "secret")
+
+    def test_map_report_interval_below_one_hour_returns_422(self) -> None:
+        resp = self.client.put(
+            "/api/config/mqtt",
+            json={
+                "enabled": True,
+                "broker_host": "mqtt.example.com",
+                "broker_port": 1883,
+                "topic_root": "msh",
+                "region_segment": "US",
+                "publish_channels": ["LongFast"],
+                "map_reporting_enabled": True,
+                "map_report_interval_seconds": 3599,
+                "map_report_position_precision": 14,
+            },
+        )
+        self.assertEqual(resp.status_code, 422)
 
     def test_invalid_gateway_id_returns_400(self) -> None:
         resp = self.client.put(


### PR DESCRIPTION
## What changed

- Add opt-in native Meshtastic `MAP_REPORT_APP` publishing on `<topic_root>/<region>/2/map/`.
- Use the configured `transmit.node_id` for both the packet source and ServiceEnvelope gateway ID, keeping it separate from the capture gateway identity.
- Match Meshtastic firmware privacy constraints: public and unencrypted, MQTT-only, minimum 3600-second interval, and 12-15 position precision bits.
- Publish the configured name, static position, PORTDUINO hardware model, firmware version, region, modem preset, primary channel metadata, and locally heard Meshtastic node count.
- Add Configuration -> MQTT dashboard controls, API persistence/validation, defaults, runtime status, docs, and tests.

Closes #115

## Why

The existing MQTT publisher forwards captured traffic with a separate gateway identity. It does not publish a native map report for the configured Meshpoint transmit identity, so the Meshpoint node may not appear on the official Meshtastic map.

## Safety and compatibility

- Disabled by default.
- Requires MQTT plus configured `device.latitude`, `device.longitude`, and `transmit.node_id`.
- Does not use LoRa airtime or change radio behavior.
- Retries after connection/config readiness, then publishes no more than once per configured interval.
- Uses the official ServiceEnvelope and MapReport protobufs and `/2/map/` topic shape.

## Testing

- `27 passed`: MapReport formatter/publisher/coordinator, MQTT API, and node repository targeted tests.
- `938 passed, 68 subtests passed`: broad suite excluding hardware/update tests that require `sudo` and `/opt/meshpoint` on the host.
- Full local run reached 957 passes; eight update/rollback tests failed only because this sandbox cannot execute `sudo` or write `/opt/meshpoint`.
- `node --check frontend/js/configuration/mqtt_card.js`
- Import/unused checks and `git diff --check` passed for changed files.

## Hardware and region

- Protocol output validated by decoding the generated ServiceEnvelope with the official Meshtastic Python protobufs.
- EU_868 / LongFast configuration covered by tests.
- No live Pi/concentrator deployment was performed for this branch. No RF path is changed.

## Risks

The report intentionally shares public node identity and approximate location data. The feature is explicit opt-in, clearly labeled in the dashboard and documentation, and bounded to the Meshtastic-supported privacy range and cadence.

## AI assistance

This focused change was developed with Codex assistance and reviewed through targeted protocol tests plus the broader project test suite.