### PR TITLE
Return bearer token from login for non-browser clients

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+#### Auth
+
+- **Bearer token on login for non-browser clients.** `POST /api/auth/login` still sets the HttpOnly session cookie for browsers. Callers that send `X-Meshpoint-Client` (companion apps) also receive the JWT in the JSON body as `token`, matching the existing `Authorization: Bearer` path.
+
 #### Capture and serial
 
 - **Busy Meshtastic serial no longer kills the service.** If a configured USB

--- a/src/api/routes/auth_routes.py
+++ b/src/api/routes/auth_routes.py
@@ -17,8 +17,9 @@ contract is auditable.
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
 from src.api.audit import AuditLogWriter
@@ -158,13 +159,25 @@ async def setup_password(
 
 @router.post("/login")
 async def login(
-    payload: LoginRequest, request: Request, response: Response
+    payload: LoginRequest,
+    request: Request,
+    response: Response,
+    x_meshpoint_client: Optional[str] = Header(default=None),
 ) -> dict:
     result = _service().login(payload.username, payload.password)
     if isinstance(result, LoginSuccess):
         _set_session_cookie(request, response, result.token)
         logger.info("user logged in (role=%s)", result.role)
-        return {"role": result.role}
+        body: dict = {"role": result.role}
+        # Raw token only in the JSON body for non-browser clients that
+        # opt in via X-Meshpoint-Client (e.g. companion apps send "app").
+        # Browser logins stay cookie-only so HttpOnly XSS protection is
+        # not undercut by exposing the JWT to page JS. Non-browser
+        # clients have no cookie jar and need the token for
+        # ``Authorization: Bearer`` (see dependencies.py).
+        if x_meshpoint_client:
+            body["token"] = result.token
+        return body
     raise _reject_login(result)
 
 

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -106,6 +106,20 @@ class TestLoginEndpoint(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["role"], "admin")
+        self.assertNotIn("token", response.json())
+        self.assertIn(SESSION_COOKIE_NAME, response.cookies)
+
+    def test_login_with_client_header_returns_bearer_token(self) -> None:
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": _PASSWORD},
+            headers={"X-Meshpoint-Client": "app"},
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["role"], "admin")
+        self.assertIn("token", body)
+        self.assertTrue(body["token"])
         self.assertIn(SESSION_COOKIE_NAME, response.cookies)
 
     def test_login_wrong_password_returns_401(self) -> None:


### PR DESCRIPTION
## Summary
- `POST /api/auth/login` still sets the HttpOnly session cookie for browsers.
- Callers that send `X-Meshpoint-Client` (companion apps) also get `token` in the JSON body so they can use `Authorization: Bearer`.
- Tests cover cookie-only browser login vs header opt-in bearer response.
- Unreleased CHANGELOG note; Flutter companion app stays out of this repo.

## Context
javastraat's companion fleet apps need a clean JWT issuance path. Bearer auth was already accepted on the API; login only returned a cookie. This is the edge hook only (no Flutter tree).

## Test plan
- [x] `python -m pytest tests/test_auth_routes.py tests/test_auth_dependencies.py -q`
- [x] `ruff check` on touched files
- [ ] Spot-check browser login still cookie-only (no `token` in body)
- [ ] Companion app login with `X-Meshpoint-Client: app` receives `token`