### PR TITLE
Fix local map watermark with OSM dark tiles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Unreleased
 
+#### Dashboard
+
+- **Local map tiles.** OSM raster with a dark invert filter, replacing
+  CARTO Dark Matter after anonymous CARTO raster requests started
+  returning an API-key watermark.
+
 #### Docs
 
 - **Bobcat 300 capture yaml.** Step 5 now uses `capture.concentrator_spi_device`

--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -255,8 +255,23 @@ html, body {
     overflow: hidden;
 }
 
+#map .leaflet-tile-pane {
+    filter: invert(1) hue-rotate(180deg) saturate(0.22) brightness(0.72) contrast(1.22);
+}
+
+#map .leaflet-control-attribution {
+    background: rgba(7, 11, 20, 0.82) !important;
+    color: var(--text-muted) !important;
+    font-size: 10px !important;
+}
+
+#map .leaflet-control-attribution a {
+    color: var(--accent-cyan) !important;
+}
+
 .leaflet-container {
     overflow: hidden !important;
+    background: var(--bg-primary) !important;
 }
 
 .leaflet-control-layers {

--- a/frontend/js/components/node_map.js
+++ b/frontend/js/components/node_map.js
@@ -37,9 +37,8 @@ class NodeMap {
             this._map.setView(MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM);
         }
 
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-            attribution: '&copy; CARTO',
-            subdomains: 'abcd',
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>',
             maxZoom: 19,
         }).addTo(this._map);
 


### PR DESCRIPTION
## Summary
- CARTO started watermarking anonymous Dark Matter raster tiles. The local Dashboard now uses OSM tiles plus a dark invert filter (no shared API key).
- Attribution stays visible. Validated on a RAK V2 Dashboard at town and world zoom.

## Test plan
- [x] Watermark gone on local map
- [x] Markers/clusters still cyan (tile pane only inverted)
- [ ] After merge: Settings to Updates stays on Stable; git pull on a Meshpoint picks this up with no version bump